### PR TITLE
Add validation for the version

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,6 +1,7 @@
-FROM mikefarah/yq:3.3.2
+FROM mikefarah/yq:3.3.2 as yq
+FROM quay.io/submariner/shipyard-dapper-base:devel
 
+COPY --from=yq /usr/bin/yq /usr/bin/
 ENV DAPPER_SOURCE=/releases
-ENV SCRIPTS_DIR=${DAPPER_SOURCE}/scripts
 
 WORKDIR ${DAPPER_SOURCE}

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
-DAPPER := ./.dapper -m bind
+ifneq (,$(DAPPER_SOURCE))
 
-include Makefile.dapper
-
-shell:
-	$(DAPPER)
+# Running in Dapper
 
 validate:
 	$(DAPPER) ./scripts/validate.sh
+
+else
+
+# Not running in Dapper
+
+include Makefile.dapper
+
+endif
 
 # Disable rebuilding Makefile
 Makefile Makefile.dapper: ;

--- a/scripts/lib/yaml_funcs
+++ b/scripts/lib/yaml_funcs
@@ -1,7 +1,10 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 function printerr() {
-    printf "ERROR: %s\n" "$*" >&2
+    local err_msg="$*"
+
+    [[ -z "${file}" ]] || err_msg+=" (${file})"
+    printf "ERROR: %s\n" "${err_msg}" >&2
 }
 
 function get_value() {
@@ -17,7 +20,7 @@ function validate_value() {
     local value=$(get_value $file $key | tr -d [:space:])
 
     if [[ -z "$value" ]]; then
-        printerr "Missing value for '${key}' in ${file}"
+        printerr "Missing value for ${key@Q}"
         return 1
     fi
 }


### PR DESCRIPTION
The validation checks that the version is taggable using git.

For this, we need to use an image that has git so might as well use
Shipyard's image which already has git (anbd a bunch of other things).

Resolves #2 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>