### PR TITLE
Add validation for admiral version

### DIFF
--- a/releases/example.yaml
+++ b/releases/example.yaml
@@ -13,7 +13,7 @@ release-notes:
     by the administrator.
 components:
   admiral: v0.5.0 # tag is possible
-  submariner: v0.5.0-rc0 # even pre-release tag
+  submariner: v0.5.0
   lighthouse: 9d0d2ef6768c78a844fc8933fa3d246a37705b81 # full commit-id only
   submariner-operator: 445669b443982c6c55cc283731df0e47d85270a2
   submariner-charts: 7cc50b03d3f6e3bc4fa75a6db344dea87693dea3

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -5,6 +5,7 @@ set -e
 source ${DAPPER_SOURCE}/scripts/lib/yaml_funcs
 
 readonly PROJECTS=(admiral lighthouse shipyard submariner submariner-charts submariner-operator)
+readonly ADMIRAL_CONSUMERS=(lighthouse submariner)
 
 function validate_file_fields() {
     local missing=0
@@ -27,6 +28,17 @@ function validate_file_fields() {
         printerr "Missing ${missing} fields"
         return 1
     fi
+}
+
+function validate_admiral_consumers() {
+    local expected_version="$1"
+    for project in ${ADMIRAL_CONSUMERS[*]}; do
+        local actual_version=$(grep admiral "${project}/go.mod" | cut -f2 -d' ')
+        if [[ "${expected_version}" != "${actual_version}" ]]; then
+            printerr "Expected Admiral version ${expected_version} but found ${actual_version} in ${project}"
+            return 1
+        fi
+    done
 }
 
 function validate_file() {
@@ -52,6 +64,7 @@ function validate_file() {
         popd
     done
 
+    validate_admiral_consumers "${release["components.admiral"]}"
     popd
     rm -rf projects
 }


### PR DESCRIPTION
The validation makes sure the release is using the specified admiral
vesion in the go.mod

Resolves #5 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>