### PR TITLE
Run E2E job only on PRs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,10 +1,5 @@
 on:
   pull_request:
-  push:
-    branches:
-      - master
-    tags:
-      - 'v**'
 
 name: End to End Tests
 jobs:


### PR DESCRIPTION
It's not necessary to run the job on push since that gives us
no extra information, so removed that trigger.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>