### PR TITLE
Use `git clone` to clone the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .dapper
 .shflags
 output
+projects

--- a/releases/example.yaml
+++ b/releases/example.yaml
@@ -16,7 +16,7 @@ release-notes: |
       by the administrator.
 components:
   admiral: v0.6.1  # tag is possible
-  submariner: v0.6.1
+  submariner: 7ffe614 # short commit-id is accepted
   lighthouse: v0.6.1
   submariner-operator: v0.6.1
   submariner-charts: 7cc50b03d3f6e3bc4fa75a6db344dea87693dea3 # full commit-id also

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -30,4 +30,19 @@ function read_release_file() {
     done
 }
 
+function _git() {
+    git -C "projects/${project}" $@
+}
+
+function clone_repo() {
+    if [[ -d "projects/${project}" ]]; then
+        _git fetch -f --tags
+    else
+        mkdir -p projects
+        git clone "https://github.com/submariner-io/${project}" "projects/${project}"
+        _git config advice.detachedHead false
+    fi
+
+    _git checkout "${release["components.${project}"]}"
+}
 


### PR DESCRIPTION
This allows us to use full commit ids, short hashes and tags for the
components, and also allows us to fetch the correct image by calculating
the image version from the commit itself (in case its not a tag).

This should allow us to use `gh release` with short commit ids (which it
doesnt support) (Enables #28)

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>