### PR TITLE
Add pre-release support

### DIFF
--- a/releases/example.yaml
+++ b/releases/example.yaml
@@ -2,6 +2,7 @@
 # This example file shows a final release stage where the file has all the fields filled
 version: v0.6.1
 name: the mighty 0.6 release!  # The name will be used for the GH release
+pre-release: false # Set to `true` to release it as a pre-release
 # Contents of release notes should be markdown formatted as that's what
 # GitHub uses
 release-notes: |

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -35,6 +35,7 @@ function read_release_file() {
 
     _read 'version'
     _read 'name'
+    _read 'pre-release'
     _read 'release-notes'
     _read 'status'
     _read 'components'

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,9 +17,10 @@ function create_release() {
     local target="$2"
     local files="${@:3}"
     local org=$(determine_org)
+    [[ "${release['pre-release']}" = "true" ]] && local prerelease="--prerelease"
 
     gh config set prompt disabled
-    gh release create "${release['version']}" $files \
+    gh release create "${release['version']}" $files $prerelease \
         --title "${release['name']}" \
         --repo "${org}/${project}" \
         --target "${target}" \

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -83,6 +83,16 @@ function validate_release() {
         return 1
     fi
 
+    if [[ "${release['pre-release']}" = "true" ]] && [[ ! "${release['version']}" =~ -[0-9a-z\.]+$ ]]; then
+        printerr "Version ${version} should have a hyphen followed by identifiers as it's marked as pre-release"
+        return 1
+    fi
+
+    if [[ "${release['pre-release']}" != "true" ]] && [[ "${release['version']}" =~ - ]]; then
+        printerr "Version ${version} should not have a hyphen as it isn't marked as pre-release"
+        return 1
+    fi
+
     case "${release['status']}" in
     shipyard)
         local project=shipyard


### PR DESCRIPTION
We can now mark pre-releases in the YAML to be released as such.

Resolves #30 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>