### PR TITLE
Don't fail E2E in case target isn't `released`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ e2e:
 	source $${DAPPER_SOURCE}/scripts/lib/utils; \
 	determine_target_release; \
 	read_release_file; \
-	[ "$${release['status']}" = "released" ] && $(MAKE) _e2e
+	[ "$${release['status']}" != "released" ] || $(MAKE) _e2e
 
 clusters: subctl
 


### PR DESCRIPTION
In case the target release isn't in that state yet we want to
successfully abort, hence the conditional needs to be different or
`make` will fail the run

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>