### PR TITLE
Add submariner-operator to Admiral consumers

### DIFF
--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly PROJECTS=(admiral lighthouse shipyard submariner submariner-charts submariner-operator)
-readonly ADMIRAL_CONSUMERS=(lighthouse submariner)
+readonly ADMIRAL_CONSUMERS=(lighthouse submariner submariner-operator)
 readonly SHIPYARD_CONSUMERS=(admiral lighthouse submariner submariner-operator)
 readonly OPERATOR_CONSUMES=(submariner lighthouse)
 


### PR DESCRIPTION
Seems it also relies on Admiral now, so add it as a consumer

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>