### PR TITLE
Release should tag all the images

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -163,7 +163,7 @@ function release_all() {
         create_project_release
     done
 
-    tag_images || errors=$((errors+1))
+    tag_all_images || errors=$((errors+1))
 }
 
 ### Main ###


### PR DESCRIPTION
Dues to a mistake the incorrect call was made, release should tag all
the images

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>