### PR TITLE
Annotate git tags

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -138,7 +138,7 @@ function tag_images() {
     local images="$@"
 
     # Creating a local tag so that images are uploaded with it
-    git tag -f "${release['version']}"
+    git tag -a -f "${release['version']}" -m "${release['version']}"
 
     make release RELEASE_ARGS="$images --tag ${release['version']}"
 }

--- a/scripts/subctl.sh
+++ b/scripts/subctl.sh
@@ -20,7 +20,7 @@ function dapper_in_dapper() {
 
     # Commit and tag so that we get a correct "version" calculated
     git commit -a -m "DAPPER IN DAPPER"
-    git tag -f ${release["version"]}
+    git tag -a -f "${release['version']}" -m "${release['version']}"
 }
 
 function cleanup_dapper_in_dapper() {


### PR DESCRIPTION
Annotating git tags allows git describe to prefer the latest tag,
which avoids problems when single commits get multiple tags (because
the project doesn't change between rc0 and rc1, for example).

Signed-off-by: Stephen Kitt <skitt@redhat.com>