### PR TITLE
Support stable branches

### DIFF
--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -17,6 +17,7 @@ function _pull_image() {
 function pull_images() {
     for project in ${PROJECTS[*]}; do
         clone_repo
+        checkout_project_branch
         local project_version=$(_git describe --tags --exclude="${CUTTING_EDGE}" --exclude="latest")
 
         for image in ${project_images[${project}]}; do
@@ -27,4 +28,8 @@ function pull_images() {
 
 determine_target_release
 read_release_file
+
+# If we're creating branches, no need to pull images as they won't exist and aren't needed yet anyhow
+[[ "${release['state']}" != "branch" ]] || exit 0
+
 pull_images

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -40,6 +40,7 @@ function read_release_file() {
     _read 'pre-release'
     _read 'release-notes'
     _read 'status'
+    _read 'branch'
     _read 'components'
     for project in ${PROJECTS[*]}; do
         _read "components.${project}"
@@ -51,7 +52,6 @@ function _git() {
 }
 
 function clone_repo() {
-    local branch="${release["components.${project}"]:-master}"
     if [[ -d "projects/${project}" ]]; then
         _git fetch -f --tags
     else
@@ -59,6 +59,12 @@ function clone_repo() {
         git clone "https://github.com/${ORG}/${project}" "projects/${project}"
         _git config advice.detachedHead false
     fi
+
+}
+
+function checkout_project_branch() {
+    local base_branch="origin/${release['branch']:-master}"
+    local branch="${release["components.${project}"]:-${base_branch}}"
 
     _git checkout "${branch}"
 }

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -5,6 +5,8 @@ readonly ADMIRAL_CONSUMERS=(lighthouse submariner submariner-operator)
 readonly SHIPYARD_CONSUMERS=(admiral lighthouse submariner submariner-operator)
 readonly OPERATOR_CONSUMES=(submariner lighthouse)
 
+readonly ORG=$(git config --get remote.origin.url | awk -F'[:/]' '{print $(NF-1)}')
+
 function printerr() {
     local err_msg="$*"
 
@@ -54,7 +56,7 @@ function clone_repo() {
         _git fetch -f --tags
     else
         mkdir -p projects
-        git clone "https://github.com/submariner-io/${project}" "projects/${project}"
+        git clone "https://github.com/${ORG}/${project}" "projects/${project}"
         _git config advice.detachedHead false
     fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -55,7 +55,7 @@ function clone_and_create_branch() {
 function update_go_mod() {
     local target="$1"
     if [[ ! -f projects/${project}/go.mod ]]; then
-        return
+        return 1
     fi
 
     # Run in subshell so we don't change the working directory even on failure
@@ -95,8 +95,15 @@ function tag_images() {
 
 ### Functions: Branch Stage ###
 
+function update_shipyard_base() {
+    sed -i -E "s/(shipyard-dapper-base):.*/\1:${release['branch']}/" projects/${project}/Dockerfile.dapper
+}
+
 function adjust_shipyard() {
+    local project=shipyard
+
     sed -e "s/devel/${branch}/" -i projects/shipyard/Makefile.versions
+    update_shipyard_base
     _git commit -a -s -m "Update Shipyard to use stable branch '${branch}'"
 }
 
@@ -105,8 +112,16 @@ function create_branches() {
 
     for project in ${PROJECTS[*]}; do
         clone_and_create_branch "${branch}" master
-        [[ "${project}" != "shipyard" ]] || adjust_shipyard
-        push_to_repo "${branch}"
+    done
+
+    adjust_shipyard
+    for project in ${SHIPYARD_CONSUMERS[*]}; do
+        update_shipyard_base
+        _git commit -a -s -m "Update Shipyard base image to use stable branch '${branch}'"
+    done
+
+    for project in ${PROJECTS[*]}; do
+        push_to_repo "${branch}" || errors=$((errors+1))
     done
 }
 
@@ -114,16 +129,8 @@ function create_branches() {
 
 function pin_to_shipyard() {
     clone_and_create_branch pin_shipyard
-    sed -i -E "s/(shipyard-dapper-base):.*/\1:${release['version']#v}/" projects/${project}/Dockerfile.dapper
     update_go_mod shipyard
     create_pr pin_shipyard "Pin Shipyard to ${release['version']}"
-}
-
-function unpin_from_shipyard() {
-    clone_repo
-    _git checkout -B unpin_shipyard origin/master
-    sed -i -E "s/(shipyard-dapper-base):.*/\1:devel/" projects/${project}/Dockerfile.dapper
-    create_pr unpin_shipyard "Un-Pin Shipyard after ${release['version']} released"
 }
 
 function release_shipyard() {
@@ -190,13 +197,6 @@ function release_all() {
     for project in ${PROJECTS[*]}; do
         create_project_release $project
     done
-
-    # Create a PR to un-pin Shipyard on every one of its consumers, but only on GA releases
-    if [[ "${release['pre-release']}" != "true" ]]; then
-        for project in ${SHIPYARD_CONSUMERS[*]}; do
-            unpin_from_shipyard || errors=$((errors+1))
-        done
-    fi
 }
 
 function post_reviews_comment() {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,21 +8,16 @@ source ${SCRIPTS_DIR}/lib/debug_functions
 
 ### Functions: General ###
 
-function determine_org() {
-    git config --get remote.origin.url | awk -F'[:/]' '{print $(NF-1)}'
-}
-
 function create_release() {
     local project="$1"
     local target="$2"
     local files="${@:3}"
-    local org=$(determine_org)
     [[ "${release['pre-release']}" = "true" ]] && local prerelease="--prerelease"
 
     gh config set prompt disabled
     gh release create "${release['version']}" $files $prerelease \
         --title "${release['name']}" \
-        --repo "${org}/${project}" \
+        --repo "${ORG}/${project}" \
         --target "${target}" \
         --notes "${release['release-notes']}"
 }
@@ -72,12 +67,11 @@ function update_go_mod() {
 function create_pr() {
     local branch="$1"
     local msg="$2"
-    local org=$(determine_org)
     export GITHUB_TOKEN="${RELEASE_TOKEN}"
 
     _git commit -a -s -m "${msg}"
-    _git push -f https://${GITHUB_ACTOR}:${RELEASE_TOKEN}@github.com/${org}/${project}.git ${branch}
-    reviews+=($(gh pr create --repo "${org}/${project}" --head ${branch} --base master --title "${msg}" --body "${msg}"))
+    _git push -f https://${GITHUB_ACTOR}:${RELEASE_TOKEN}@github.com/${ORG}/${project}.git ${branch}
+    reviews+=($(gh pr create --repo "${ORG}/${project}" --head ${branch} --base master --title "${msg}" --body "${msg}"))
 }
 
 function tag_images() {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -105,6 +105,22 @@ function adjust_shipyard() {
     sed -e "s/devel/${branch}/" -i projects/shipyard/Makefile.versions
     update_shipyard_base
     _git commit -a -s -m "Update Shipyard to use stable branch '${branch}'"
+
+    # Run in subshell so we don't change the working directory even on failure
+    (
+        set -e
+
+        # Trick our own Makefile to think we're running outside dapper
+        export DAPPER_HOST_ARCH=""
+
+        # Rebuild Shipyard image with the changes we made for stable branches
+        cd projects/shipyard
+        make images
+    )
+
+    # Upload shipyard base image so that other projects have it immediately
+    # Otherwise, image building jobs are likely to fail when creating the branches
+    make release RELEASE_ARGS="shipyard-dapper-base --tag='${release['branch']}'"
 }
 
 function create_branches() {

--- a/scripts/subctl.sh
+++ b/scripts/subctl.sh
@@ -38,6 +38,7 @@ read_release_file
 
 project=submariner-operator
 clone_repo
+checkout_project_branch
 
 pushd projects/submariner-operator
 dapper_in_dapper


### PR DESCRIPTION
This adds support for creating stable branches, and changes the release behavior so that Shipyard image is only pinned when a stable branch is created.