### PR TITLE
Make sure to declare KUBECONFIG before the tests

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -7,6 +7,8 @@ source ${SCRIPTS_DIR}/lib/debug_functions
 source ${SCRIPTS_DIR}/lib/utils
 
 determine_target_release
+declare_kubeconfig
+
 # TODO: Add bask service-discovery tests once theyre stable
 subctl verify --only "connectivity" --submariner-namespace ${SUBM_NS} --verbose --connection-timeout 20 --connection-attempts 4 \
     ${KUBECONFIGS_DIR}/kind-config-cluster1 \


### PR DESCRIPTION
Due to a regression [1] this is now necessary, we may remove it if the
regressions is fixed or we may need to keep it.

[1] https://github.com/submariner-io/submariner-operator/issues/1209

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>