### PR TITLE
Add cloud-prepare to release process

### DIFF
--- a/releases/example-partial.yaml
+++ b/releases/example-partial.yaml
@@ -22,4 +22,5 @@ components:
   shipyard: 2254d86 # Only used if status is 'shipyard'
   admiral: a69b58d # Only used if status is 'admiral'
   submariner: 7ffe614 # Only used if status is 'projects'
+  cloud-prepare: 6729657 # Only used if status is 'projects'
   lighthouse: 6c78a05 # Only used if status is 'projects'

--- a/releases/example.yaml
+++ b/releases/example.yaml
@@ -21,6 +21,7 @@ components:
   admiral: v0.6.1  # tag is possible
   submariner: 7ffe614 # short commit-id is accepted
   lighthouse: v0.6.1
+  cloud-prepare: 6729657
   submariner-operator: v0.6.1
   submariner-charts: 7cc50b03d3f6e3bc4fa75a6db344dea87693dea3 # full commit-id also
   shipyard: v0.6.1

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-readonly PROJECTS=(admiral lighthouse shipyard submariner submariner-charts submariner-operator)
-readonly ADMIRAL_CONSUMERS=(lighthouse submariner submariner-operator)
+readonly PROJECTS=(admiral cloud-prepare lighthouse shipyard submariner submariner-charts submariner-operator)
+readonly ADMIRAL_CONSUMERS=(cloud-prepare lighthouse submariner submariner-operator)
 readonly SHIPYARD_CONSUMERS=(admiral lighthouse submariner submariner-operator)
 readonly OPERATOR_CONSUMES=(submariner lighthouse)
 


### PR DESCRIPTION
Cloud-prepare should be released as part of our unified release process.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>