### PR TITLE
Add cloud-prepare to operator dependencies

### DIFF
--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -3,7 +3,7 @@
 readonly PROJECTS=(admiral cloud-prepare lighthouse shipyard submariner submariner-charts submariner-operator)
 readonly ADMIRAL_CONSUMERS=(cloud-prepare lighthouse submariner submariner-operator)
 readonly SHIPYARD_CONSUMERS=(admiral lighthouse submariner submariner-operator)
-readonly OPERATOR_CONSUMES=(submariner lighthouse)
+readonly OPERATOR_CONSUMES=(submariner cloud-prepare lighthouse)
 
 readonly ORG=$(git config --get remote.origin.url | awk -F'[:/]' '{print $(NF-1)}')
 


### PR DESCRIPTION
Now that `cloud prepare` commands are part of subctl, it'd be best if
auto release syncs up the operator's dependency.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>