### PR TITLE
Don't do a shallow clone while running the release scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Create the release
         env:

--- a/releases/v0.9.0.yaml
+++ b/releases/v0.9.0.yaml
@@ -3,3 +3,4 @@ version: v0.9.0
 name: 0.9.0
 branch: release-0.9
 status: branch
+# bump


### PR DESCRIPTION
Otherwise:

  git diff-tree --name-only -r HEAD

will return empty output, and we can't detect
if releases/vx.x.x.. has been modified.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
