### PR TITLE
Add CII badge, remove PR-triggered badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # Releases
 
 <!-- markdownlint-disable line-length -->
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4865/badge)](https://bestpractices.coreinfrastructure.org/projects/4865)
 [![Release](https://github.com/submariner-io/releases/workflows/Release%20the%20Target%20Release/badge.svg)](https://github.com/submariner-io/releases/actions?query=workflow%3A%22Release+the+Target+Release%22)
-[![End to End Tests](https://github.com/submariner-io/releases/workflows/End%20to%20End%20Tests/badge.svg)](https://github.com/submariner-io/releases/actions?query=workflow%3A%22End+to+End+Tests%22)
-[![Linting](https://github.com/submariner-io/releases/workflows/Linting/badge.svg)](https://github.com/submariner-io/releases/actions?query=workflow%3ALinting)
 [![Periodic](https://github.com/submariner-io/releases/workflows/Periodic/badge.svg)](https://github.com/submariner-io/releases/actions?query=workflow%3APeriodic)
-[![Validation](https://github.com/submariner-io/releases/workflows/Validation/badge.svg)](https://github.com/submariner-io/releases/actions?query=workflow%3AValidation)
 <!-- markdownlint-enable line-length -->
 
 This repository is WIP, but will eventually contain release process logic for submariner-io projects.


### PR DESCRIPTION
Add Submariner's CII Best Practices badge to the README.

Remove badges for workflows triggered by PRs, as their status reflects
tests against proposed/WIP code, not merged code. This causes false red
flags, reducing the utility of the badges overall. Leave badges for
workflows run against merged code.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>