### PR TITLE
Attempt to enable auto merge on generated PRs

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -5,7 +5,7 @@ COPY --from=yq /usr/bin/yq /usr/bin/
 ENV DAPPER_SOURCE=/releases PATH=/releases/scripts:$PATH DAPPER_DOCKER_SOCKET=true \
     DAPPER_ENV="GITHUB_ACTOR GITHUB_TOKEN MAKEFLAGS QUAY_USERNAME QUAY_PASSWORD RELEASE_TOKEN"
 ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output \
-    GH_VERSION=1.3.1
+    GH_VERSION=1.10.3
 
 RUN curl -L https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz | tar xzf - && mv gh_${GH_VERSION}_linux_${ARCH}/bin/gh /usr/bin/ && rm -rf gh_${GH_VERSION}_linux_${ARCH}
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -101,7 +101,9 @@ function create_pr() {
 
     _git commit -a -s -m "${msg}"
     push_to_repo "${branch}"
-    reviews+=($(dryrun gh pr create --repo "${ORG}/${project}" --head ${branch} --base "${base_branch}" --title "${msg}" --body "${msg}"))
+    local to_review=$(dryrun gh pr create --repo "${ORG}/${project}" --head ${branch} --base "${base_branch}" --title "${msg}" --body "${msg}")
+    dryrun gh pr merge --auto --repo "${ORG}/${project}" --squash "${to_review}" || echo "WARN: Failed to enable auto merge on ${to_review}"
+    reviews+=("${to_review}")
 }
 
 function tag_images() {


### PR DESCRIPTION
To facilitate an easier workflow, attempt to enable auto merge on a PR
once it's created.
In case of falure we don't want the whole release to abort, so we'll
just print a warning.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
