### PR TITLE
Added dry-run release GHA

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -14,3 +14,23 @@ jobs:
 
       - name: Validate release YAMLs
         run: make validate
+
+  # This job runs the script in "dryrun" mode, not doing any changes to the repo.
+  # This should make sure the script at least works as intended (given a valid yaml).
+  release:
+    name: Dry-run the Release
+    needs: yamls
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create the release in dry-run mode
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: make create-release dryrun=true

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ import-images: images
 	./scripts/import-images.sh
 
 create-release: config-git images
-	./scripts/release.sh $(CREATE_RELEASE_ARGS)
+	./scripts/release.sh
 
 validate:
 	./scripts/validate.sh

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,15 +1,5 @@
 #!/usr/bin/env bash
 
-## Process command line flags ##
-
-source ${SCRIPTS_DIR}/lib/shflags
-DEFINE_boolean 'dryrun' false "Set to 'true' to run without affecting any online repositories"
-
-FLAGS "$@" || exit $?
-eval set -- "${FLAGS_ARGV}"
-
-[[ "${FLAGS_dryrun}" = "${FLAGS_TRUE}" ]] && dryrun=true || dryrun=false
-
 set -e
 
 source ${DAPPER_SOURCE}/scripts/lib/image_defs
@@ -108,8 +98,8 @@ function create_pr() {
 
 function release_images() {
     local args="$1"
-    make release-images RELEASE_ARGS="${args}" || \
-        make release RELEASE_ARGS="${args}"
+    dryrun make release-images RELEASE_ARGS="${args}" || \
+        dryrun make release RELEASE_ARGS="${args}"
 }
 
 function tag_images() {
@@ -118,7 +108,7 @@ function tag_images() {
     # Creating a local tag so that images are uploaded with it
     git tag -a -f "${release['version']}" -m "${release['version']}"
 
-    dryrun release_images "$images --tag ${release['version']}"
+    release_images "$images --tag ${release['version']}"
 }
 
 ### Functions: Branch Stage ###
@@ -152,7 +142,7 @@ function adjust_shipyard() {
         make images IMAGES_ARGS="--buildargs 'SUBCTL_VERSION=devel'"
     )
 
-    dryrun release_images "shipyard-dapper-base --tag='${release['branch']}'"
+    release_images "shipyard-dapper-base --tag='${release['branch']}'"
 }
 
 function create_branches() {


### PR DESCRIPTION
This will run the release in a "dry run" mode (not making any actual
changes) and this should at least validate that the release process
should pass when run on merge.

Also made sure dryrun is run for actual commands (excluding _git which
is a util command).

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
