### PR TITLE
Remove `Dockerfile.dapper` update on branching

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -114,7 +114,6 @@ function tag_images() {
 ### Functions: Branch Stage ###
 
 function update_base_branch() {
-    sed -i -E "s/(shipyard-dapper-base):.*/\1:${release['branch']}/" projects/${project}/Dockerfile.dapper
     sed -i -E "s/^(BASE_BRANCH.*= *)devel$/\1${release['branch']}/" projects/${project}/Makefile
     sed -i -E "s/\<devel\>/${release['branch']}/" projects/${project}/.github/workflows/*
 }


### PR DESCRIPTION
Since [1] the Dockerfile.dapper is usually taken from Shipyard, but even
if not all our consuming projects now use `${BASE_BRANCH}` when
referring to the version, which is set in `Makefile`, so this isn't
necessary anymore.

[1] https://github.com/submariner-io/shipyard/pull/573

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
