### PR TITLE
Use makeflags instead of env vars

### DIFF
--- a/scripts/subctl.sh
+++ b/scripts/subctl.sh
@@ -31,10 +31,9 @@ checkout_project_branch
 pushd projects/submariner-operator
 dapper_in_dapper
 
-export DEFAULT_IMAGE_VERSION=${release["version"]}
-export VERSION=${release["version"]}
-[[ "$1" == "cross" ]] && make build-cross
-make bin/subctl
+target=( bin/subctl )
+[[ "$1" == "cross" ]] && target+=( build-cross )
+make "${target[@]}" VERSION="${release['version']}" DEFAULT_IMAGE_VERSION="${release['version']}"
 
 ln -f -s $(pwd)/bin/subctl /go/bin/subctl
 ./bin/subctl version


### PR DESCRIPTION
This will allow us to get rid of `Dockerfile.dapper` on
submariner-operator, and should be a bit more robust.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
