### PR TITLE
Remove `--notes` from `gh release create`

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -25,13 +25,14 @@ function create_release() {
     local target="$2"
     local files=( "${@:3}" )
     [[ "${release['pre-release']}" = "true" ]] && local prerelease="--prerelease"
+#    [[ -n "${release['release-notes']}" ]] && local notes="--notes ${release['release-notes']}"
 
     gh config set prompt disabled
-    dryrun gh release create "${release['version']}" "${files[@]}" "$prerelease" \
+    # shellcheck disable=SC2086
+    dryrun gh release create "${release['version']}" "${files[@]}" "${prerelease}" \
         --title "${release['name']}" \
         --repo "${ORG}/${project}" \
-        --target "${target}" \
-        --notes "${release['release-notes']}"
+        --target "${target}"
 }
 
 function create_project_release() {


### PR DESCRIPTION
It seems to fail if `--notes` is empty, remove for now

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
