### PR TITLE
Fix subctl building

### DIFF
--- a/scripts/subctl.sh
+++ b/scripts/subctl.sh
@@ -11,15 +11,18 @@ set -e
 
 # Allow running dapper in dapper by some trickery
 function dapper_in_dapper() {
+    # Trick our own Makefile to think we're running outside dapper
+    export DAPPER_HOST_ARCH=""
+
+    # Make sure we have Dockerfile.dapper as it could be in Shipyard and needs to be fetched
+    make Dockerfile.dapper
+
     # Plant a directive in the Dockerfile.dapper to let dapper run in dapper
     local orig_pwd
     local cur_pwd
     orig_pwd=$(docker inspect "$HOSTNAME" | jq -r ".[0].Mounts[] | select(.Destination == \"$DAPPER_SOURCE\") | .Source")
     cur_pwd=$(pwd | sed -E 's/[a-zA-Z0-9-]+/../g')
     echo "ENV DAPPER_CP=${cur_pwd}/${orig_pwd}/projects/submariner-operator" >> Dockerfile.dapper
-
-    # Trick our own Makefile to think we're running outside dapper
-    export DAPPER_HOST_ARCH=""
 }
 
 ### Main ###


### PR DESCRIPTION
Since now `Dockerfile.dapper` lives in Shipyard, we need to make sure it
exists before trying to modify it

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
