### PR TITLE
When checking links, ignore GHA links

### DIFF
--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -4,6 +4,12 @@
       "pattern": "^https://github.com/\\S+/\\S+/(issues|pull)/[0-9]+"
     },
     {
+      "pattern": "^https://github.com/\\S+/\\S+/actions"
+    },
+    {
+      "pattern": "^https://github.com/settings/tokens"
+    },
+    {
       "pattern": "^https://github.com/submariner-io/releases/workflows/(.*)/badge.svg"
     },
     {


### PR DESCRIPTION
Links such as
https://github.com/submariner-io/releases/actions?query=workflow%3APeriodic
are only accessible when authenticated.

This was flagged by the periodic link checker (see
.github/ISSUE_TEMPLATE/broken-link.md).

Fixes: #181
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
