### PR TITLE
Skip goproxy when retrieving a pin target

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -74,7 +74,7 @@ function update_go_mod() {
     # Run in subshell so we don't change the working directory even on failure
     (
         pushd "projects/${project}"
-        go get "github.com/submariner-io/${target}@${release['version']}"
+        GOPROXY=direct go get "github.com/submariner-io/${target}@${release['version']}"
         go mod vendor
         go mod tidy
     )


### PR DESCRIPTION
We've seen goproxy 410 errors when retrieving the pin target; to avoid
those, this skips the proxy.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
