### PR TITLE
Fix E2E failure on branching phase

### DIFF
--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -79,6 +79,10 @@ function checkout_project_branch() {
     local base_branch="origin/${release['branch']:-devel}"
     local branch="${release["components.${project}"]:-${base_branch}}"
 
+    if [[ "${release['status']}" = "branch" ]]; then
+        branch=devel
+    fi
+
     _git reset --hard HEAD
     _git checkout "${branch}"
 }


### PR DESCRIPTION
When checking out the project branch, use `devel` when the status is `branch` since the branch hasn't been created yet.

Fixes https://github.com/submariner-io/releases/issues/197
