### PR TITLE
Tidy up before downloading pinned libraries

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -75,6 +75,8 @@ function update_go_mod() {
     # Run in subshell so we don't change the working directory even on failure
     (
         pushd "projects/${project}"
+
+        go mod tidy
         with_retries 50 go get "github.com/submariner-io/${target}@${release['version']}"
         go mod vendor
         go mod tidy


### PR DESCRIPTION
It seems that go.sum could be messed up, leading to failure to download
the newest version of a released library, as seen in #199.

Tidying up before attempting the download should resolve this.

Resolves: #199 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
