### PR TITLE
Always use upstream as org for `make release`

### DIFF
--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -6,7 +6,7 @@ readonly ADMIRAL_CONSUMERS=(cloud-prepare lighthouse submariner submariner-opera
 readonly SHIPYARD_CONSUMERS=(admiral lighthouse submariner submariner-operator)
 readonly OPERATOR_CONSUMES=(submariner cloud-prepare lighthouse)
 
-readonly ORG=$(git config --get remote.origin.url | awk -F'[:/]' '{print $(NF-1)}')
+ORG=$(git config --get remote.origin.url | awk -F'[:/]' '{print $(NF-1)}')
 declare -A NEXT_STATUS=( [branch]=shipyard [shipyard]=admiral [admiral]=projects [projects]=released )
 
 function printerr() {
@@ -65,14 +65,11 @@ function _git() {
 }
 
 function clone_repo() {
-    if [[ -d "projects/${project}" ]]; then
-        _git fetch -f --tags
-    else
-        mkdir -p projects
-        git clone "https://github.com/${ORG}/${project}" "projects/${project}"
-        _git config advice.detachedHead false
-    fi
+    [[ -d "projects/${project}" ]] && rm -rf "projects/${project}"
 
+    mkdir -p projects
+    git clone "https://github.com/${ORG}/${project}" "projects/${project}"
+    _git config advice.detachedHead false
 }
 
 function checkout_project_branch() {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,6 +7,8 @@ source "${DAPPER_SOURCE}/scripts/lib/image_defs"
 source "${DAPPER_SOURCE}/scripts/lib/utils"
 source "${SCRIPTS_DIR}/lib/debug_functions"
 
+ORG=submariner-io
+
 ### Functions: General ###
 
 function expect_env() {


### PR DESCRIPTION
Don't use forks, always use the upstream

Resolves: #211 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
