### PR TITLE
Skip E2E on branching phase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ ifneq (,$(filter dryrun,$(_using)))
 override CREATE_RELEASE_ARGS += --dryrun
 endif
 
-TARGET_RELEASE = $(shell . scripts/lib/utils && determine_target_release 2&> /dev/null && echo $${file})
+E2E_NEEDED = $(shell . scripts/lib/utils && \
+    determine_target_release 2&> /dev/null && \
+    read_release_file && \
+    exit_on_branching && echo true)
 
 config-git:
 	git config --global user.email "$(GIT_EMAIL)";\
@@ -28,8 +31,12 @@ config-git:
 subctl: config-git
 	./scripts/subctl.sh $(SUBCTL_ARGS)
 
-e2e: $(if $(TARGET_RELEASE),deploy)
+ifeq (true, $(E2E_NEEDED))
+e2e: deploy
 	./scripts/e2e.sh
+else
+e2e: ;
+endif
 
 clusters: images subctl
 

--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -30,8 +30,5 @@ function pull_images() {
 
 determine_target_release
 read_release_file
-
-# If we're creating branches, no need to pull images as they won't exist and aren't needed yet anyhow
-[[ "${release['status']}" != "branch" ]] || exit 0
-
+exit_on_branching
 pull_images

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -93,3 +93,7 @@ function extract_semver() {
     declare -gA semver
     IFS=".-" read -r semver['major'] semver['minor'] semver['patch'] semver['pre'] <<< "$1"
 }
+
+function exit_on_branching() {
+    [[ "${release['status']}" != "branch" ]] || exit 0
+}


### PR DESCRIPTION
When we're just creating branches there's no need to run E2E.

Resolves: #197 

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
