### PR TITLE
Revert "Add retries in update_go_mod"

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -7,7 +7,6 @@ set -e
 # shellcheck source=scripts/lib/utils
 . "${DAPPER_SOURCE}/scripts/lib/utils"
 . "${SCRIPTS_DIR}/lib/debug_functions"
-. "${SCRIPTS_DIR}/lib/utils"
 
 ### Functions: General ###
 
@@ -77,7 +76,7 @@ function update_go_mod() {
         pushd "projects/${project}"
 
         go mod tidy
-        with_retries 50 go get "github.com/submariner-io/${target}@${release['version']}"
+        GOPROXY=direct go get "github.com/submariner-io/${target}@${release['version']}"
         go mod vendor
         go mod tidy
     )


### PR DESCRIPTION
This reverts commit ea8ea4ec51425a41ffe2c92ef8814fccaf37d23b.

The reason is that the go proxy can take several minutes (even tens of
minutes) to update, and no reasonable amount of retries makes sense in
such a case since it slows down the release process considerably.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
