### PR TITLE
Fix dryrun related things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,6 @@ CLUSTER_SETTINGS_FLAG = --cluster_settings $(DAPPER_SOURCE)/scripts/cluster_sett
 override CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
 override DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG) --deploytool_broker_args '--service-discovery'
 
-ifneq (,$(filter dryrun,$(_using)))
-override CREATE_RELEASE_ARGS += --dryrun
-endif
-
 E2E_NEEDED = $(shell . scripts/lib/utils && \
     determine_target_release 2&> /dev/null && \
     read_release_file && \
@@ -53,7 +49,7 @@ import-images: images
 	./scripts/import-images.sh
 
 release: config-git
-	./scripts/release.sh $(RELEASE_ARGS)
+	./scripts/release.sh
 
 test-release:
 	./scripts/test/release.sh

--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -11,16 +11,6 @@ set -e
 
 ### Functions: General ###
 
-# Use this function to dry run a command (in dry run mode), instead of actually running the command
-function dryrun() {
-    if [[ "$dryrun" = "true" ]]; then
-        echo DRY RUNNING: "${@:Q}"
-        return
-    fi
-
-    "$@"
-}
-
 function create_release() {
     local project="$1"
     local target="$2"

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -53,7 +53,7 @@ function read_release_file() {
 # Based on global "dryrun" variable
 function dryrun() {
     if [[ "$dryrun" = "true" ]]; then
-        echo DRY RUNNING: "${@:Q}"
+        echo DRY RUNNING: "${@:1}"
         return
     fi
 


### PR DESCRIPTION
The `using=dryrun` syntax doesnt really do anything, so remove it.

Remove original `dryrun` function as it's now in utils.

Fix printing not to print the script name

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
