### PR TITLE
fix: the path for the default operator versions

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -203,7 +203,7 @@ function update_operator_pr() {
         update_go_mod "${target}"
     done
 
-    sed -i -E "s/(.*Version +=) .*/\1 \"${release['version']#v}\"/" "projects/${project}/pkg/versions/versions.go"
+    sed -i -E "s/(.*Version +=) .*/\1 \"${release['version']#v}\"/" "projects/${project}/apis/submariner/v1alpha1/versions.go"
     create_pr update_operator "Update Operator to use version ${release['version']}"
 }
 


### PR DESCRIPTION
Signed-off-by: Steve Mattar <smattar@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
