### PR TITLE
Make sure `make release` uses correct base branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BASE_BRANCH ?= devel
 GIT_EMAIL ?= release@submariner.io
 GIT_NAME ?= Automated Release
 SHELLCHECK_ARGS := scripts/lib/* scripts/*.sh
+export BASE_BRANCH
 export GIT_EMAIL
 export GIT_NAME
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -49,7 +49,8 @@ function set_status() {
 function create_pr() {
     local branch="$1"
     local msg="$2"
-    local base_branch="${release['branch']:-devel}"
+    # shellcheck disable=SC2153
+    local base_branch="${BASE_BRANCH}"
     local pr_to_review
     local project
 


### PR DESCRIPTION
When creating PRs use the global base branch instead of the one in the
file, since we're creaing the PR to the `releases` repository itself.

Resolves: #196

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
