### PR TITLE
Fix images handling for stable branches

### DIFF
--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -20,7 +20,8 @@ function pull_images() {
         local project_version
         clone_repo
         checkout_project_branch
-        project_version=$(cd "projects/${project}" && make print-version | grep -oP "(?<=CALCULATED_VERSION=).+")
+        project_version=$(cd "projects/${project}" && make print-version BASE_BRANCH="${release['branch']:-devel}" | \
+                          grep -oP "(?<=CALCULATED_VERSION=).+")
 
         for image in ${project_images[${project}]}; do
             _pull_image "$project_version"


### PR DESCRIPTION
The image loading script is calling `make` inside the container, which
already has `BASE_BRANCH` initialized.
Specifying the `BASE_BRANCH` explicitly makes sure we're using the exact
stable branch we want to use.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
