### PR TITLE
Use gh from shipyard-dapper-base

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -4,10 +4,7 @@ FROM quay.io/submariner/shipyard-dapper-base:devel
 COPY --from=yq /usr/bin/yq /usr/bin/
 ENV DAPPER_SOURCE=/releases PATH=/releases/scripts:$PATH DAPPER_DOCKER_SOCKET=true \
     DAPPER_ENV="GIT_EMAIL GIT_NAME GITHUB_ACTOR GITHUB_TOKEN MAKEFLAGS QUAY_USERNAME QUAY_PASSWORD RELEASE_TOKEN"
-ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output \
-    GH_VERSION=1.10.3
-
-RUN curl -L https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz | tar xzf - && mv gh_${GH_VERSION}_linux_${ARCH}/bin/gh /usr/bin/ && rm -rf gh_${GH_VERSION}_linux_${ARCH}
+ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output
 
 WORKDIR ${DAPPER_SOURCE}
 ENTRYPOINT ["/opt/shipyard/scripts/entry"]


### PR DESCRIPTION
The Shipyard base image now includes gh, use that instead of
downloading it in our Dapper image.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
