### PR TITLE
Ignore `vendor` directory when version pinning

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -204,7 +204,7 @@ function update_operator_pr() {
     done
 
     local versions_file
-    versions_file=$(grep -l -r --include='*.go' 'Default.*Version *=' projects/${project}/)
+    versions_file=$(grep -l -r --include='*.go' --exclude-dir=vendor 'Default.*Version *=' projects/${project}/)
     [[ -n "${versions_file}" ]] || { printerr "Can't find file for default image versions"; return 1; }
 
     sed -i -E "s/(Default.*Version *=) .*/\1 \"${release['version']#v}\"/" "${versions_file}"


### PR DESCRIPTION
Otherwise it might try to modify vendor files which is unnecessary.

Resolves #294

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
