### PR TITLE
Add e2e-all-k8s label to PRs

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -88,7 +88,7 @@ function create_pr() {
     _git commit -a -s -m "${msg}"
     push_to_repo "${branch}"
     to_review=$(dryrun gh pr create --repo "${ORG}/${project}" --head "${branch}" --base "${base_branch}" --title "${msg}" \
-                --label "ready-to-test" --body "${msg}")
+                --label "ready-to-test" --label "e2e-all-k8s" --body "${msg}")
     dryrun gh pr merge --auto --repo "${ORG}/${project}" --squash "${to_review}" || echo "WARN: Failed to enable auto merge on ${to_review}"
     reviews+=("${to_review}")
 }


### PR DESCRIPTION
Add a label to PRs created by the release process that will run E2E
against all relevant K8s versions if that job is available in a repo.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
