### PR TITLE
Add validation that project hash is latest

### DIFF
--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -5,6 +5,7 @@ readonly PROJECTS=(admiral cloud-prepare lighthouse shipyard submariner submarin
 readonly ADMIRAL_CONSUMERS=(cloud-prepare lighthouse submariner submariner-operator)
 readonly SHIPYARD_CONSUMERS=(admiral lighthouse submariner submariner-operator)
 readonly OPERATOR_CONSUMES=(submariner cloud-prepare lighthouse)
+readonly RELEASED_PROJECTS=(submariner-charts submariner-operator)
 
 ORG=$(git config --get remote.origin.url | awk -F'[:/]' '{print $(NF-1)}')
 declare -A NEXT_STATUS=( [branch]=shipyard [shipyard]=admiral [admiral]=projects [projects]=released )


### PR DESCRIPTION
This will make sure the hash is the latest on the github branch.
For this to work properly, we can't support version tags as project hash
anymore (not that we use it).

Resolves: #302 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
