### PR TITLE
Improvements to use GH API

### DIFF
--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -7,7 +7,7 @@ readonly SHIPYARD_CONSUMERS=(admiral lighthouse submariner submariner-operator)
 readonly OPERATOR_CONSUMES=(submariner cloud-prepare lighthouse)
 readonly RELEASED_PROJECTS=(submariner-charts submariner-operator)
 
-ORG=$(git config --get remote.origin.url | awk -F'[:/]' '{print $(NF-1)}')
+ORG=${GITHUB_ACTOR:-$(git config --get remote.origin.url | awk -F'[:/]' '{print $(NF-1)}')}
 declare -A NEXT_STATUS=( [branch]=shipyard [shipyard]=admiral [admiral]=projects [projects]=released )
 
 function printerr() {

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -98,3 +98,8 @@ function extract_semver() {
 function exit_on_branching() {
     [[ "${release['status']}" != "branch" ]] || exit 0
 }
+
+function gh_commit_sha() {
+    local ref="$1"
+    curl -sf -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${ORG}/${project}/commits/${ref}" | jq -r ".sha"
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -104,11 +104,6 @@ function validate_no_branch() {
     fi
 }
 
-function gh_commit_sha() {
-    local ref="$1"
-    curl -sf -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${ORG}/${project}/commits/${ref}" | jq -r ".sha"
-}
-
 function validate_project_commits() {
     local project="${1:-${project}}"
 


### PR DESCRIPTION
Some improvements to use GH API for commit sha information/checking instead of cloning the projects.

This should work a bit faster and also save some disk churning.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
