### PR TITLE
Add validation for "pin" pull requests

### DIFF
--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -99,7 +99,12 @@ function exit_on_branching() {
     [[ "${release['status']}" != "branch" ]] || exit 0
 }
 
+function gh_api() {
+    local call="$1"
+    curl -sf -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${ORG}/${project}/${call}"
+}
+
 function gh_commit_sha() {
     local ref="$1"
-    curl -sf -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${ORG}/${project}/commits/${ref}" | jq -r ".sha"
+    gh_api "commits/${ref}" | jq -r ".sha"
 }


### PR DESCRIPTION
Added validation to make sure previous stage's pull requests have been
merged before trying to advance to next step.

This depends on previous work that introduced a mechanism to call GH API.
Rebase once it's merged.

Depends on #311 
Fixes: #301 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
