### PR TITLE
Make sure E2E runs are robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,11 @@ CLUSTER_SETTINGS_FLAG = --settings $(DAPPER_SOURCE)/.shipyard.e2e.yml
 override CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
 override DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG)
 
+_E2E_CANARY = E2E CANARY
 E2E_NEEDED = $(shell . scripts/lib/utils && \
     determine_target_release 2&> /dev/null && \
     read_release_file && \
-    exit_on_branching && echo true)
+    exit_on_branching && echo $(_E2E_CANARY))
 
 config-git:
 	git config --global user.email "$(GIT_EMAIL)";\
@@ -28,11 +29,12 @@ config-git:
 subctl: config-git
 	./scripts/subctl.sh $(SUBCTL_ARGS)
 
-ifeq (true, $(E2E_NEEDED))
+ifneq (, $(findstring $(_E2E_CANARY),$(E2E_NEEDED)))
 e2e: deploy
 	./scripts/e2e.sh
 else
-e2e: ;
+e2e:
+	echo $(E2E_NEEDED)
 endif
 
 clusters: images subctl

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -7,7 +7,7 @@ readonly SHIPYARD_CONSUMERS=(admiral lighthouse submariner submariner-operator)
 readonly OPERATOR_CONSUMES=(submariner cloud-prepare lighthouse)
 readonly RELEASED_PROJECTS=(submariner-charts submariner-operator)
 
-echo "GITHUB_REPOSITORY_OWNER=${GITHUB_REPOSITORY_OWNER}"
+echo "GITHUB_REPOSITORY_OWNER=${GITHUB_REPOSITORY_OWNER}" >&2
 ORG=${GITHUB_REPOSITORY_OWNER:-$(git config --get remote.origin.url | awk -F'[:/]' '{print $(NF-1)}')}
 declare -A NEXT_STATUS=( [branch]=shipyard [shipyard]=admiral [admiral]=projects [projects]=released )
 


### PR DESCRIPTION
When adding prints it could break, this should make sure E2E detection
is more robust.
Also chanign printing of env var to stderr as our other debug info.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
