### PR TITLE
Make sure only the review URL is captured

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 # shellcheck source=scripts/lib/image_defs
 . "${DAPPER_SOURCE}/scripts/lib/image_defs"
@@ -96,6 +97,7 @@ function create_pr() {
         return 1
     fi
 
+    to_review=$(echo "${to_review}" | dryrun grep "http.*")
     dryrun gh pr merge --auto --repo "${ORG}/${project}" --squash "${to_review}" || echo "WARN: Failed to enable auto merge on ${to_review}"
     reviews+=("${to_review}")
 }


### PR DESCRIPTION
Since we have some debug prints they're getting captured in the output
together with the PR URL, we just want the URL

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
