### PR TITLE
Branch out `releases` on `rc0`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BASE_BRANCH ?= devel
+BASE_BRANCH = devel
 GIT_EMAIL ?= release@submariner.io
 GIT_NAME ?= Automated Release
 SHELLCHECK_ARGS := scripts/lib/* scripts/*.sh
@@ -69,7 +69,7 @@ else
 
 Makefile.dapper:
 	@echo Downloading $@
-	@curl -sfLO https://raw.githubusercontent.com/submariner-io/shipyard/$(BASE_BRANCH)/$@
+	@curl -sfLO https://raw.githubusercontent.com/submariner-io/shipyard/devel/$@
 
 include Makefile.dapper
 

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -100,6 +100,10 @@ function extract_semver() {
     IFS=".-" read -r semver['major'] semver['minor'] semver['patch'] semver['pre'] <<< "$1"
 }
 
+function stable_branch_name() {
+    echo "release-${semver['major']}.${semver['minor']}"
+}
+
 function exit_on_branching() {
     [[ "${release['status']}" != "branch" ]] || exit 0
 }


### PR DESCRIPTION
Since we're creating stable branches on `rc0` we should create the
branch on `releases` as well, so that all stable releases happen on the
branch.

This also makes sure the releases on `releases` happen on the stable
branch.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
