### PR TITLE
Fix validation for `installers`

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -185,7 +185,7 @@ function validate_release() {
         validate_no_pin_prs pin_admiral "${ADMIRAL_CONSUMERS[@]}"
         ;;
     installers)
-        validate_project_commits "${SUBCTL_CONSUMES[@]}"
+        validate_project_commits "${INSTALLER_PROJECTS[@]}"
         validate_no_pin_prs update_operator submariner-operator
         ;;
     released)


### PR DESCRIPTION
Wrong array was used, fixed to use the correct one.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
