### PR TITLE
Upload `subctl` binaries from `subctl`

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -258,7 +258,7 @@ function release_released() {
     local commit_ref
     commit_ref=$(git rev-parse --verify HEAD)
     make subctl SUBCTL_ARGS=cross
-    create_release releases "${commit_ref}" projects/submariner-operator/dist/subctl-* || errors=$((errors+1))
+    create_release releases "${commit_ref}" projects/subctl/dist/subctl-* || errors=$((errors+1))
 
     for_every_project create_project_release "${PROJECTS[@]}"
 }


### PR DESCRIPTION
Make sure we're uploading the binaries from `subctl` itself since it was
split off of `submariner-operator`.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
