### PR TITLE
Release testing improvements

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,12 +1,29 @@
 ---
 name: Testing
 
+permissions:
+  actions: write
+  contents: read
+
 on:
   pull_request:
 
 jobs:
+  skip-check:
+    name: Run tests except on release
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@9d116fa7e55f295019cfab7e3ab72b478bcf7fdd
+        with:
+          paths_ignore: '["releases/**"]'
+
   release:
     name: Make release
+    needs: skip-check
+    if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
@@ -16,3 +33,28 @@ jobs:
 
       - name: Test the `make release` command
         run: make test-release
+
+  entire-release:
+    name: Entire release process
+    needs: skip-check
+    if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ['100.0.0-m0', '100.0.0-rc0']
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          fetch-depth: 0
+
+      # Needed to properly build multi-arch Shipyard images when branching out
+      - name: Set up QEMU (to support building on non-native architectures)
+        uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
+
+      - name: Test the entire release
+        run: make test-entire-release VERSION="${{ matrix.version }}"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BASE_BRANCH ?= devel
 GIT_EMAIL ?= release@submariner.io
 GIT_NAME ?= Automated Release
-SHELLCHECK_ARGS := scripts/lib/* scripts/*.sh
+SHELLCHECK_ARGS := scripts/*.sh scripts/lib/* scripts/test/*
 export BASE_BRANCH
 export GIT_EMAIL
 export GIT_NAME

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ import-images: images
 release: config-git
 	./scripts/release.sh
 
-test-release:
-	./scripts/test/release.sh
+test-%:
+	./scripts/test/$*.sh
 
 validate:
 	./scripts/validate.sh

--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -58,6 +58,13 @@ function clone_and_create_branch() {
     _git checkout -B "${branch}" "remotes/origin/${base_branch}"
 }
 
+function _update_go_mod() {
+    go mod tidy
+    GOPROXY=direct go get "github.com/submariner-io/${target}@${release['version']}"
+    go mod vendor
+    go mod tidy
+}
+
 function update_go_mod() {
     local target="$1"
     if [[ ! -f projects/${project}/go.mod ]]; then
@@ -66,12 +73,8 @@ function update_go_mod() {
 
     # Run in subshell so we don't change the working directory even on failure
     (
-        pushd "projects/${project}"
-
-        go mod tidy
-        GOPROXY=direct go get "github.com/submariner-io/${target}@${release['version']}"
-        go mod vendor
-        go mod tidy
+        cd "projects/${project}"
+        dryrun _update_go_mod
     )
 }
 

--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -9,8 +9,8 @@ set -e
 function _pull_image() {
     local hash="${1#v}"
     local full_image="${REPO}/${image}"
-    docker pull "${full_image}:${hash}"
-    docker tag "${full_image}:${hash}" "${full_image}:${DEV_VERSION}"
+    dryrun docker pull "${full_image}:${hash}"
+    dryrun docker tag "${full_image}:${hash}" "${full_image}:${DEV_VERSION}"
 }
 
 function pull_images() {

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -120,7 +120,9 @@ function exit_on_branching() {
 
 function gh_api() {
     local call="$1"
-    curl -sf -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${ORG}/${project}/${call}"
+    local auth
+    [[ -z "${GITHUB_TOKEN}" ]] || auth=(-H "Authorization: token ${GITHUB_TOKEN}")
+    curl -sf "${auth[@]}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${ORG}/${project}/${call}"
 }
 
 function gh_commit_sha() {

--- a/scripts/subctl.sh
+++ b/scripts/subctl.sh
@@ -38,7 +38,9 @@ pushd projects/subctl
 dapper_in_dapper
 
 target=( cmd/bin/subctl )
-[[ "$1" == "cross" ]] && target+=( build-cross )
+
+# If cross build requested perform it, except when dry-running as it takes a very long time and has little benefit when testing
+[[ "$1" == "cross" && "$dryrun" != "true" ]] && target+=( build-cross )
 make "${target[@]}" VERSION="${release['version']}" DEFAULT_IMAGE_VERSION="${release['version']}"
 
 ln -f -s "$(pwd)/cmd/bin/subctl" /go/bin/subctl

--- a/scripts/test/entire-release.sh
+++ b/scripts/test/entire-release.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Always run on "main" org and not on forks that can be stale
+export GITHUB_REPOSITORY_OWNER=submariner-io
+
+source "${DAPPER_SOURCE}/scripts/lib/utils"
+source "${DAPPER_SOURCE}/scripts/test/utils"
+
+### Testing Functions ###
+
+function _test_release_step() {
+    print_test "Entire release process for version ${VERSION@Q} - current status ${status@Q}"
+
+    _make release VERSION="${VERSION}" || exit_error "Running 'make release' failed"
+    _make validate || exit_error "Running 'make validate' failed"
+    _make do-release || exit_error "Running 'make do-release' failed"
+}
+
+### Main ###
+
+base_commit=$(git rev-parse HEAD)
+trap reset_git EXIT
+
+status="shipyard"
+extract_semver "${VERSION}"
+[[ "${semver['pre']}" != "rc0" ]] || status="branch"
+
+_test_release_step
+sanitize_branch
+
+while [[ -n "${NEXT_STATUS[${status}]}" ]]; do
+    status="${NEXT_STATUS[${status}]}"
+    _test_release_step
+done
+

--- a/scripts/test/release.sh
+++ b/scripts/test/release.sh
@@ -111,13 +111,12 @@ for version in "${faulty_versions[@]}"; do
     test_semver_faulty "$version"
 done
 
-# TODO: Fix tests to account for stable branches somehow
-#test_release '100.0.0' 'shipyard'
-#test_release '100.0.1' 'shipyard'
-test_release '100.0.0-rc0' 'branch' 'pre-release: true'
-#test_release '100.0.0-rc1' 'shipyard' 'pre-release: true'
-#test_release '100.0.1-rc1' 'shipyard' 'pre-release: true'
+# Test with non-existing branches
+# Only pre-releases are expected to work as we expect RCs or formal releases to happen on a branch (which must exist)
+test_release '100.0.0-m0' 'shipyard' 'pre-release: true'
+test_release '100.0.0-rc0' 'branch' 'branch: release-100.0' 'pre-release: true'
 
 # Test with an existing known branch
-#test_release '0.9.100' 'shipyard' 'branch: release-0.9'
-#test_release '0.9.100-rc1' 'shipyard' 'branch: release-0.9' 'pre-release: true'
+# Only releases or release candidates are expected to work as we're not releasing milestones on stable branches
+test_release '0.9.100' 'shipyard' 'branch: release-0.9'
+test_release '0.9.100-rc1' 'shipyard' 'branch: release-0.9' 'pre-release: true'

--- a/scripts/test/utils
+++ b/scripts/test/utils
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+
+### General Functions ###
+
+function exit_error() {
+    echo "--------- Captured output ---------"
+    echo "${output}"
+    echo "-----------------------------------"
+    echo "ERROR: $*"
+    exit 1
+}
+
+function print_test() {
+    echo "TEST: $*"
+}
+
+function reset_git() {
+    git checkout -- releases/*
+    git reset --keep "${base_commit}" > /dev/null
+}
+
+function _make() {
+    declare -g output
+    output=$(make "${@}" dryrun=true 2>&1)
+    return "$?"
+}
+
+# In case we're targeting a branch, the commands will fail, so remove it for testing
+function sanitize_branch() {
+    if grep 'branch:' "releases/v${VERSION}.yaml" > /dev/null ; then
+        sed -i '/^branch:.*/d' "releases/v${VERSION}.yaml"
+        git commit -a -m "Remove branch or make release will fail" > /dev/null
+    fi
+}
+


### PR DESCRIPTION
This PR improves release process testing by:
1. Re-enabling tests for `make release` that were disabled when adding stable branch support.
2. Adding a new test that runs the entire release process (using a matrix strategy in GHA to parallelize the long run)
3. Some other improvements that were made to this area.

See individual commits for more details.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
5. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
6. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
7. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
8. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
9. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
