### PR TITLE
Fix early release of Shipyard images

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -141,10 +141,13 @@ function adjust_shipyard() {
         # Rebuild Shipyard image with the changes we made for stable branches
         # Make sure subctl is taken from devel, as it won't be available yet
         cd projects/shipyard
-        make images IMAGES_ARGS="--buildargs 'SUBCTL_VERSION=devel'"
-    )
+        make images multiarch-images IMAGES_ARGS="--buildargs 'SUBCTL_VERSION=devel'"
 
-    release_images "shipyard-dapper-base --tag='${release['branch']}'"
+        # This will release all of Shipyard's images
+        # TODO skitt revisit once "make release-images" accounts for images
+        # in RELEASE_ARGS
+        release_images "--tag='${release['branch']}'"
+    )
 }
 
 function create_stable_branch() {


### PR DESCRIPTION
During releases, we try to release Shipyard images early so that the
validation jobs spawned by the release don't fail because of missing
images. This relied on the fact that "make release-images" would
blindly release any locally-available image matching the name of the
image(s) it was given (including in RELEASE_ARGS). This broke with the
introduction of multi-arch image support: each project now filters its
images based on whether they're multi-arch or not, using the
MULTIARCH_IMAGES and IMAGES variables; but the actual release here
runs in the context of the "releases" project, not the project
actually producing the images, so nothing matches and nothing gets
released.

Move the image release inside the Shipyard project so that the correct
architecture determination can be made. This ends up releasing nettest
too, which we don't need, but this doesn't cause any harm.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
