### PR TITLE
When tagging images, tag inside the git repo

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -108,7 +108,7 @@ function release_images() {
 
 function tag_images() {
     # Creating a local tag so that images are uploaded with it
-    git tag -a -f "${release['version']}" -m "${release['version']}"
+    _git tag -a -f "${release['version']}" -m "${release['version']}"
 
     release_images "$* --tag ${release['version']}"
 }


### PR DESCRIPTION
Currently, the git tag for a release is created in the release
project, not the repository containing the project to be released.
This fixes that by using _git rather than git (_git runs the git
command inside the current's project repository).

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
