### PR TITLE
Automated backport of #383: Tag images inside each project repository

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -110,7 +110,7 @@ function tag_images() {
     # Creating a local tag so that images are uploaded with it
     git tag -a -f "${release['version']}" -m "${release['version']}"
 
-    release_images "$* --tag ${release['version']}"
+    in_project_repo release_images "$* --tag ${release['version']}"
 }
 
 ### Functions: Branch Stage ###

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -70,6 +70,12 @@ function _git() {
     git -C "projects/${project}" "$@"
 }
 
+function in_project_repo() {
+    local cmd="$1"
+    shift
+    (cd "projects/${project}" && "$cmd" "$@")
+}
+
 function clone_repo() {
     [[ -d "projects/${project}" ]] && rm -rf "projects/${project}"
 


### PR DESCRIPTION
Backport of #383 on release-0.13.

#383: Tag images inside each project repository

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.