### PR TITLE
Automated backport of #384: When tagging images, tag inside the git repo

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -108,7 +108,7 @@ function release_images() {
 
 function tag_images() {
     # Creating a local tag so that images are uploaded with it
-    git tag -a -f "${release['version']}" -m "${release['version']}"
+    _git tag -a -f "${release['version']}" -m "${release['version']}"
 
     release_images "$* --tag ${release['version']}"
 }


### PR DESCRIPTION
Backport of #384 on release-0.13.

#384: When tagging images, tag inside the git repo

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.