### PR TITLE
Fix `in_project_repo`

### DIFF
--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -71,9 +71,7 @@ function _git() {
 }
 
 function in_project_repo() {
-    local cmd="$1"
-    shift
-    (cd "projects/${project}" && "$cmd" "$@")
+    (cd "projects/${project}" && "$@")
 }
 
 function clone_repo() {


### PR DESCRIPTION
It fails when using `debug_functions` from Shipyard as that one declares
`cmd` and it overrides the command.

This simpler function both works and avoids the problem.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
