### PR TITLE
Fix `determine_target_release` merge detection

### DIFF
--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -22,11 +22,21 @@ function printerr() {
     printf "ERROR: %s\n" "${err_msg}" >&2
 }
 
+function count_parents() {
+    git cat-file -p "$1" | grep -c "^parent "
+}
+
 function determine_target_release() {
     local commit_id=HEAD
 
     # In case of a merge commit, select the commit before it from the 2nd head (the tree being merged)
-    [[ $(git cat-file -p HEAD | grep -c "^parent ") -gt 1 ]] && commit_id="HEAD^2"
+    if [[ $(count_parents HEAD) -gt 1 ]]; then
+        commit_id="HEAD^2"
+
+        # In case the parent is also a merge commit, select its first parent (which is the tip of the PR)
+        [[ $(count_parents HEAD^2) -gt 1 ]] && commit_id="HEAD^2^1"
+    fi
+
     file=$(git diff-tree --name-only -r "${commit_id}" | grep -m1 "releases/v.*\.yaml" || :)
 
     if [[ -z "$file" ]]; then


### PR DESCRIPTION
Sometimes using "Update branch" in GitHub causes a "double" merge commit
event, which trips up the release detection logic.

Example:
```
commit ba36cd7a36b0bfd05122759b33f5509b47bcc8d8 (HEAD, pull/381/merge)
Merge: f4f375f 302ed6d
Author: Mike Kolesnik <mkolesni@redhat.com>
Date:   Tue Jun 21 08:42:09 2022 +0300

    Merge 302ed6d0d436261851023deb8c14c5d7271829b6 into f4f375f772506de5c8f10423c6417aa4a6c6b74a

commit 302ed6d0d436261851023deb8c14c5d7271829b6 (origin/releasing-0.13.0-rc0)
Merge: 2a94578 f4f375f
Author: Mike Kolesnik <mkolesni@redhat.com>
Date:   Tue Jun 21 08:42:08 2022 +0300

    Merge branch 'release-0.13' into releasing-0.13.0-rc0
```

Fixed the logic to account for the possibility that the merged commit is
a merge commit by itself.
In this case, the 1st parent of the 2nd parent of the original commit,
is the tip of the PR we're updating.

In the example, the 2nd parent is `302ed6d` which in itself is a merge
commit where the 1st parent `2a94578` is the PR branch
(releasing-0.13.0-rc0).

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
