### PR TITLE
Branch out `releases` on `rc0`

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -151,6 +151,7 @@ function adjust_shipyard() {
 }
 
 function create_stable_branch() {
+    local project=${1:-${project}}
     local branch="${release['branch']}"
     [[ "$project" != "shipyard" ]] || return 0
 
@@ -161,6 +162,10 @@ function create_stable_branch() {
 }
 
 function release_branch() {
+
+    # Branch out `releases` itself, in order to allow changes in release process on devel.
+    # Further release logic needs to happen on the stable branch.
+    create_stable_branch releases
 
     # Shipyard needs some extra care since everything else relies on it
     adjust_shipyard


### PR DESCRIPTION
Since we're creating stable branches on `rc0` we should create the
branch on `releases` as well, so that all stable releases happen on the
branch.

This step must happen on the CI since:
1. It creates a branch owned by the bot, not an individual contributor.
2. At this point, we're creating branches for all projects, which will
   trigger image builds for these branches.
   These images will then be available for any further release on that
   stable branch.

This also makes sure the releases on `releases` happen on the stable
branch.
When releasing a stable release, it must happen on the stable branch
itself (should it exist).

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
