### PR TITLE
Copy container images with Skopeo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To create or advance a release, simply run `make release VERSION='$semver'`, e.g
 * `make release VERSION='1.2.3'
 * `make release VERSION='1.2.3-rc1'
 
-To run the process without pushing the changes to GitHub, run the command with `dryrun=true`.
+To run the process without making external changes (GitHub, Quay...), run the command with `dryrun=true`.
 
 Make sure you set the `GITHUB_TOKEN` environment variable to a [Personal Access Token](https://github.com/settings/tokens) which has
 at least `public_repo` access to your repository.

--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -35,15 +35,17 @@ function create_project_release() {
         return
     fi
 
+    # If the project has container images, copy them to the release tag
+    # This will fail if the source images don't exist; abort then without trying to create the release
+    if [[ -n "$(project_images)" ]] && ! tag_images "$(project_images)"; then
+        ((errors++))
+        return 1
+    fi
+
     # Release the project on GitHub so that it gets tagged
     export GITHUB_TOKEN="${RELEASE_TOKEN}"
     commit_ref=$(_git rev-parse --verify HEAD)
     create_release "${project}" "${commit_ref}" || errors=$((errors+1))
-
-    # Tag the project's container images, if there are any to tag
-    if [[ -n "$(project_images)" ]]; then
-        tag_images "$(project_images)" || errors=$((errors+1))
-    fi
 }
 
 function clone_and_create_branch() {
@@ -107,10 +109,18 @@ function release_images() {
 }
 
 function tag_images() {
-    # Creating a local tag so that images are uploaded with it
-    _git tag -a -f "${release['version']}" -m "${release['version']}"
-
-    in_project_repo release_images "$* --tag ${release['version']}"
+    # Tag the images matching the release commit using the release tag
+    local project_version
+    project_version=$(cd "projects/${project}" && make print-version BASE_BRANCH="${release['branch']:-devel}" | \
+                      grep -oP "(?<=CALCULATED_VERSION=).+")
+    local hash="${project_version#v}"
+    
+    echo "$QUAY_PASSWORD" | dryrun skopeo login quay.io -u "$QUAY_USERNAME" --password-stdin
+    for image; do
+        local full_image="${REPO}/${image}"
+        # --all ensures we handle multi-arch images correctly; it works with single- and multi-arch
+        dryrun skopeo copy --all "docker://${full_image}:${hash}" "docker://${full_image}:${release['version']}"
+    done
 }
 
 ### Functions: Branch Stage ###


### PR DESCRIPTION
Instead of relying on local images pulled previously, use Skopeo to
tag previously-tagged images on Quay with the release tag. This
handles multi-arch images correctly and increases performance since
there's less data to transfer.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
