### PR TITLE
Split project_images' output for tag_images

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -37,7 +37,8 @@ function create_project_release() {
 
     # If the project has container images, copy them to the release tag
     # This will fail if the source images don't exist; abort then without trying to create the release
-    if [[ -n "$(project_images)" ]] && ! tag_images "$(project_images)"; then
+    # shellcheck disable=SC2046 # We need to split $(project_images)
+    if [[ -n "$(project_images)" ]] && ! tag_images $(project_images); then
         ((errors++))
         return 1
     fi


### PR DESCRIPTION
We need to process each component of project_images' output
separately.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
