### PR TITLE
Automated backport of #396: Split project_images' output for tag_images

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -9,6 +9,6 @@ jobs:
     name: PR targets branch
     runs-on: ubuntu-latest
     steps:
-      - name: Check that the PR targets devel
-        if: ${{ github.base_ref != 'devel' }}
+      - name: Check that the PR targets release-0.13
+        if: ${{ github.base_ref != 'release-0.13' }}
         run: exit 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,10 +20,10 @@ jobs:
           fetch-depth: 0
 
       - name: Run E2E deployment and tests
-        uses: submariner-io/shipyard/gh-actions/e2e@devel
+        uses: submariner-io/shipyard/gh-actions/e2e@release-0.13
         with:
           using: ${{ matrix.globalnet }}
 
       - name: Post mortem
         if: failure()
-        uses: submariner-io/shipyard/gh-actions/post-mortem@devel
+        uses: submariner-io/shipyard/gh-actions/post-mortem@release-0.13

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Release the Target Release
 on:
   push:
     branches:
-      - devel
+      - release-0.13
     paths:
       - 'releases/**'
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BASE_BRANCH ?= devel
+BASE_BRANCH = release-0.13
 GIT_EMAIL ?= release@submariner.io
 GIT_NAME ?= Automated Release
 SHELLCHECK_ARGS := scripts/lib/* scripts/*.sh

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To create or advance a release, simply run `make release VERSION='$semver'`, e.g
 * `make release VERSION='1.2.3'
 * `make release VERSION='1.2.3-rc1'
 
-To run the process without pushing the changes to GitHub, run the command with `dryrun=true`.
+To run the process without making external changes (GitHub, Quay...), run the command with `dryrun=true`.
 
 Make sure you set the `GITHUB_TOKEN` environment variable to a [Personal Access Token](https://github.com/settings/tokens) which has
 at least `public_repo` access to your repository.

--- a/releases/v0.13.0-rc0.yaml
+++ b/releases/v0.13.0-rc0.yaml
@@ -1,4 +1,5 @@
 ---
+# Bump
 version: v0.13.0-rc0
 name: 0.13.0-rc0
 pre-release: true

--- a/releases/v0.13.0-rc0.yaml
+++ b/releases/v0.13.0-rc0.yaml
@@ -3,4 +3,6 @@ version: v0.13.0-rc0
 name: 0.13.0-rc0
 pre-release: true
 branch: release-0.13
-status: branch
+status: shipyard
+components:
+  shipyard: e63cdfc7cee944002e681a2db26fb45d12cb10c3

--- a/releases/v0.13.0-rc0.yaml
+++ b/releases/v0.13.0-rc0.yaml
@@ -1,0 +1,6 @@
+---
+version: v0.13.0-rc0
+name: 0.13.0-rc0
+pre-release: true
+branch: release-0.13
+status: branch

--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -108,7 +108,7 @@ function release_images() {
 
 function tag_images() {
     # Creating a local tag so that images are uploaded with it
-    git tag -a -f "${release['version']}" -m "${release['version']}"
+    _git tag -a -f "${release['version']}" -m "${release['version']}"
 
     in_project_repo release_images "$* --tag ${release['version']}"
 }

--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -141,10 +141,13 @@ function adjust_shipyard() {
         # Rebuild Shipyard image with the changes we made for stable branches
         # Make sure subctl is taken from devel, as it won't be available yet
         cd projects/shipyard
-        make images IMAGES_ARGS="--buildargs 'SUBCTL_VERSION=devel'"
-    )
+        make images multiarch-images IMAGES_ARGS="--buildargs 'SUBCTL_VERSION=devel'"
 
-    release_images "shipyard-dapper-base --tag='${release['branch']}'"
+        # This will release all of Shipyard's images
+        # TODO skitt revisit once "make release-images" accounts for images
+        # in RELEASE_ARGS
+        release_images "--tag='${release['branch']}'"
+    )
 }
 
 function create_stable_branch() {

--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -149,7 +149,7 @@ function adjust_shipyard() {
 
 function create_stable_branch() {
     local branch="${release['branch']}"
-    [[ "$project" != "shipyard" ]] || return
+    [[ "$project" != "shipyard" ]] || return 0
 
     clone_and_create_branch "${branch}" devel
     update_base_branch

--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -35,15 +35,17 @@ function create_project_release() {
         return
     fi
 
+    # If the project has container images, copy them to the release tag
+    # This will fail if the source images don't exist; abort then without trying to create the release
+    if [[ -n "$(project_images)" ]] && ! tag_images "$(project_images)"; then
+        ((errors++))
+        return 1
+    fi
+
     # Release the project on GitHub so that it gets tagged
     export GITHUB_TOKEN="${RELEASE_TOKEN}"
     commit_ref=$(_git rev-parse --verify HEAD)
     create_release "${project}" "${commit_ref}" || errors=$((errors+1))
-
-    # Tag the project's container images, if there are any to tag
-    if [[ -n "$(project_images)" ]]; then
-        tag_images "$(project_images)" || errors=$((errors+1))
-    fi
 }
 
 function clone_and_create_branch() {
@@ -107,10 +109,18 @@ function release_images() {
 }
 
 function tag_images() {
-    # Creating a local tag so that images are uploaded with it
-    _git tag -a -f "${release['version']}" -m "${release['version']}"
-
-    in_project_repo release_images "$* --tag ${release['version']}"
+    # Tag the images matching the release commit using the release tag
+    local project_version
+    project_version=$(cd "projects/${project}" && make print-version BASE_BRANCH="${release['branch']:-devel}" | \
+                      grep -oP "(?<=CALCULATED_VERSION=).+")
+    local hash="${project_version#v}"
+    
+    echo "$QUAY_PASSWORD" | dryrun skopeo login quay.io -u "$QUAY_USERNAME" --password-stdin
+    for image; do
+        local full_image="${REPO}/${image}"
+        # --all ensures we handle multi-arch images correctly; it works with single- and multi-arch
+        dryrun skopeo copy --all "docker://${full_image}:${hash}" "docker://${full_image}:${release['version']}"
+    done
 }
 
 ### Functions: Branch Stage ###

--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -37,7 +37,8 @@ function create_project_release() {
 
     # If the project has container images, copy them to the release tag
     # This will fail if the source images don't exist; abort then without trying to create the release
-    if [[ -n "$(project_images)" ]] && ! tag_images "$(project_images)"; then
+    # shellcheck disable=SC2046 # We need to split $(project_images)
+    if [[ -n "$(project_images)" ]] && ! tag_images $(project_images); then
         ((errors++))
         return 1
     fi

--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -110,7 +110,7 @@ function tag_images() {
     # Creating a local tag so that images are uploaded with it
     git tag -a -f "${release['version']}" -m "${release['version']}"
 
-    release_images "$* --tag ${release['version']}"
+    in_project_repo release_images "$* --tag ${release['version']}"
 }
 
 ### Functions: Branch Stage ###

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -71,9 +71,7 @@ function _git() {
 }
 
 function in_project_repo() {
-    local cmd="$1"
-    shift
-    (cd "projects/${project}" && "$cmd" "$@")
+    (cd "projects/${project}" && "$@")
 }
 
 function clone_repo() {

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -70,6 +70,12 @@ function _git() {
     git -C "projects/${project}" "$@"
 }
 
+function in_project_repo() {
+    local cmd="$1"
+    shift
+    (cd "projects/${project}" && "$cmd" "$@")
+}
+
 function clone_repo() {
     [[ -d "projects/${project}" ]] && rm -rf "projects/${project}"
 


### PR DESCRIPTION
Backport of #396 on release-0.13.

#396: Split project_images' output for tag_images

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.