### PR TITLE
Drop the images dependency on do-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ clusters: images subctl
 deploy: import-images
 
 # [do-release] will run the release process for the current stage, creating tags and releasing images as needed
-do-release: config-git images
+do-release: config-git
 	./scripts/do-release.sh
 
 images:


### PR DESCRIPTION
Images are now tagged directly in the repository, we no longer need to
have them locally to perform a release.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
