### PR TITLE
Add retries to GH release creation

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -5,6 +5,7 @@ set -o pipefail
 
 # shellcheck source=scripts/lib/utils
 . "${DAPPER_SOURCE}/scripts/lib/utils"
+. "${SCRIPTS_DIR}/lib/utils"
 . "${SCRIPTS_DIR}/lib/debug_functions"
 
 ### Functions: General ###
@@ -18,7 +19,7 @@ function create_release() {
 
     gh config set prompt disabled
     # shellcheck disable=SC2086,SC2068 # Some things have to be expanded or GH CLI flips out
-    dryrun gh release create "${release['version']}" ${files[@]} ${prerelease} \
+    with_retries 3 dryrun gh release create "${release['version']}" ${files[@]} ${prerelease} \
         --title "${release['name']}" \
         --repo "${ORG}/${project}" \
         --target "${target}"


### PR DESCRIPTION
To avoid failing due to transient network/server errors, retry the
release a couple time if it fails.

Resolves: #360 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
