### PR TITLE
[Backport] Tag images inside each project repository

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -113,7 +113,7 @@ function tag_images() {
     # Creating a local tag so that images are uploaded with it
     git tag -a -f "${release['version']}" -m "${release['version']}"
 
-    release_images "$* --tag ${release['version']}"
+    in_project_repo release_images "$* --tag ${release['version']}"
 }
 
 ### Functions: Branch Stage ###

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -76,6 +76,12 @@ function _git() {
     git -C "projects/${project}" "$@"
 }
 
+function in_project_repo() {
+    local cmd="$1"
+    shift
+    (cd "projects/${project}" && "$cmd" "$@")
+}
+
 function clone_repo() {
     [[ -d "projects/${project}" ]] && rm -rf "projects/${project}"
 


### PR DESCRIPTION
tag_images relies on "make release-images", which now needs to know
its project's MULTIARCH_IMAGES and IMAGES settings. To account for
this, make sure tag_images runs inside the relevant project, using the
new in_project_repo function.

Signed-off-by: Stephen Kitt <skitt@redhat.com>
(cherry picked from commit a550102e6ef0bbfef431ef1ca62084ab2e5d8315)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
