### PR TITLE
[Backport] Fix return statement for skipping Shipyard

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -167,7 +167,7 @@ function adjust_shipyard() {
 
 function create_stable_branch() {
     local branch="${release['branch']}"
-    [[ "$project" != "shipyard" ]] || return
+    [[ "$project" != "shipyard" ]] || return 0
 
     clone_and_create_branch "${branch}" devel
     update_base_branch


### PR DESCRIPTION
An empty return just return the last exit code (which in this case isn't
0).

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>
(cherry picked from commit fa1405a916a7f9e58c454005f8d8e3f3ff441262)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
