### PR TITLE
Run validation on `make release`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,6 +32,9 @@ jobs:
           fetch-depth: 0
 
       - name: Test the `make release` command
+        env:
+          # Needed for testing as we're running validations which hit the GH API rate limit
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make test-release
 
   entire-release:
@@ -57,4 +60,7 @@ jobs:
         uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
 
       - name: Test the entire release
+        env:
+          # Needed for testing as we're running validations which hit the GH API rate limit
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make test-entire-release VERSION="${{ matrix.version }}"

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -80,6 +80,11 @@ function _git() {
     git -C "projects/${project}" "$@"
 }
 
+function reset_git() {
+    git checkout -- releases/*
+    git reset --keep "${base_commit}" > /dev/null
+}
+
 function in_project_repo() {
     (cd "projects/${project}" && "$@")
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -74,6 +74,15 @@ function sync_upstream() {
     git rebase "upstream_releases/${BASE_BRANCH}"
 }
 
+# Validates the created commit to make sure we're not missing anything
+function validate_commit {
+    if ! make validate; then
+        printerr "Failed to run validation for the commit, please attend any reported errors and try again."
+        reset_git
+        exit 1
+    fi
+}
+
 ### Functions: Creating initial release ###
 
 function create_pr() {
@@ -173,6 +182,7 @@ function advance_stage() {
         set_status "${next}"
         # shellcheck disable=SC2086
         advance_${release['status']}
+        validate_commit
         create_pr "releasing-${VERSION}" "Advancing ${VERSION} release to status: ${next}"
         ;;
     released)
@@ -188,6 +198,7 @@ function advance_stage() {
 ### Main ###
 
 extract_semver "$VERSION"
+base_commit=$(git rev-parse HEAD)
 sync_upstream
 validate
 

--- a/scripts/test/release.sh
+++ b/scripts/test/release.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Always run on "main" org and not on forks that can be stale
+export GITHUB_REPOSITORY_OWNER=submariner-io
+
 source "${DAPPER_SOURCE}/scripts/lib/utils"
 source "${DAPPER_SOURCE}/scripts/test/utils"
 

--- a/scripts/test/utils
+++ b/scripts/test/utils
@@ -16,11 +16,6 @@ function print_test() {
     echo "TEST: $*"
 }
 
-function reset_git() {
-    git checkout -- releases/*
-    git reset --keep "${base_commit}" > /dev/null
-}
-
 function _make() {
     declare -g output
     output=$(make "${@}" dryrun=true 2>&1)

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -131,7 +131,7 @@ function validate_no_pin_prs() {
     shift
 
     for project; do
-        if ! pin_prs="$(gh_api "pulls?base=${release['branch']:-devel}&head=${ORG}:${head}&state=open" | jq -r ".[].url")"; then
+        if ! pin_prs="$(gh_api "pulls?base=${release['branch']:-devel}&head=${ORG}:${head}&state=open" | jq -r ".[].html_url")"; then
             printerr "Failed to list pull requests for ${project}."
             return 1
         fi


### PR DESCRIPTION
Running the validation  on the created commit ensures that it won't fail
in CI due to various reasons (e.g. previous step didn't finish yet).

Resolves: #403

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
