### PR TITLE
Remove `SUBCTL_VERSION` when building images

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -157,9 +157,8 @@ function adjust_shipyard() {
         export DAPPER_HOST_ARCH=""
 
         # Rebuild Shipyard image with the changes we made for stable branches
-        # Make sure subctl is taken from devel, as it won't be available yet
         cd projects/shipyard
-        make images multiarch-images IMAGES_ARGS="--buildargs 'SUBCTL_VERSION=devel'"
+        make images multiarch-images
 
         # This will release all of Shipyard's images
         # TODO skitt revisit once "make release-images" accounts for images


### PR DESCRIPTION
We don't ship `subctl` inside the Shipyard images for a long while now,
so no need to specify this build arg.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
