### PR TITLE
Use ENV vars instead of flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,7 @@ ifneq (,$(DAPPER_SOURCE))
 
 include $(SHIPYARD_DIR)/Makefile.inc
 
-CLUSTER_SETTINGS_FLAG = --settings $(DAPPER_SOURCE)/.shipyard.e2e.yml
-override CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
-override DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG)
+export SETTINGS = $(DAPPER_SOURCE)/.shipyard.e2e.yml
 
 _E2E_CANARY = E2E CANARY
 E2E_NEEDED = $(shell . scripts/lib/utils && \

--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -110,12 +110,6 @@ function create_pr() {
     reviews+=("${to_review}")
 }
 
-function release_images() {
-    local args="$1"
-    dryrun make release-images RELEASE_ARGS="${args}" || \
-        dryrun make release RELEASE_ARGS="${args}"
-}
-
 function tag_images() {
     # Tag the images matching the release commit using the release tag
     local project_version
@@ -161,9 +155,7 @@ function adjust_shipyard() {
         make images multiarch-images
 
         # This will release all of Shipyard's images
-        # TODO skitt revisit once "make release-images" accounts for images
-        # in RELEASE_ARGS
-        release_images "--tag='${release['branch']}'"
+        dryrun make release-images TAG="${release['branch']}"
     )
 }
 


### PR DESCRIPTION
Switch to using Shipyard's ENV vars instead of flags, much simpler to
understand.

Depends on https://github.com/submariner-io/shipyard/pull/890

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
