### PR TITLE
Unify dependency updates, use branch specific name

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -125,20 +125,19 @@ function validate_project_commits() {
     done
 }
 
-function validate_no_pin_prs() {
-    local head="$1"
-    local pin_prs
-    shift
+function validate_no_update_prs() {
+    local head="update-dependencies-${release['branch']:-devel}"
+    local update_prs
 
     for project; do
-        if ! pin_prs="$(gh_api "pulls?base=${release['branch']:-devel}&head=${ORG}:${head}&state=open" | jq -r ".[].html_url")"; then
+        if ! update_prs="$(gh_api "pulls?base=${release['branch']:-devel}&head=${ORG}:${head}&state=open" | jq -r ".[].html_url")"; then
             printerr "Failed to list pull requests for ${project}."
             return 1
         fi
 
-        if [[ -n "${pin_prs}" ]]; then
+        if [[ -n "${update_prs}" ]]; then
             printerr "Found open ${head@Q} pull requests on ${project}, make sure they're merged before proceeding"
-            echo "${pin_prs}"
+            echo "${update_prs}"
             return 1
         fi
     done
@@ -178,19 +177,19 @@ function validate_release() {
         ;;
     admiral)
         validate_project_commits admiral
-        validate_no_pin_prs pin_shipyard "${SHIPYARD_CONSUMERS[@]}"
+        validate_no_update_prs "${SHIPYARD_CONSUMERS[@]}"
         ;;
     projects)
         validate_project_commits "${PROJECTS_PROJECTS[@]}"
-        validate_no_pin_prs pin_admiral "${ADMIRAL_CONSUMERS[@]}"
+        validate_no_update_prs "${ADMIRAL_CONSUMERS[@]}"
         ;;
     installers)
         validate_project_commits "${INSTALLER_PROJECTS[@]}"
-        validate_no_pin_prs update_operator submariner-operator
+        validate_no_update_prs "${INSTALLER_PROJECTS[@]}"
         ;;
     released)
         validate_project_commits "${RELEASED_PROJECTS[@]}"
-        validate_no_pin_prs update_subctl subctl
+        validate_no_update_prs "${RELEASED_PROJECTS[@]}"
         ;;
     esac
 


### PR DESCRIPTION
Unify dependency updates as they work mostly the same, and use a branch
specific name for the created branch.
This allows us to run multiple releases simultaneously for different
branches, while keeping the core code simple.

Resolves #464 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
