### PR TITLE
When upgrading releases, tidy before vendor

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -61,8 +61,8 @@ function clone_and_create_branch() {
 function _update_go_mod() {
     go mod tidy -compat=1.17
     GOPROXY=direct go get "github.com/submariner-io/${target}@${release['version']}"
-    go mod vendor
     go mod tidy -compat=1.17
+    go mod vendor
 }
 
 function update_go_mod() {


### PR DESCRIPTION
go mod tidy now needs to run before go mod vendor, to ensure that all
the required hashes in go.sum are populated.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
