### PR TITLE
Fix branch name detection in push

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -105,7 +105,7 @@ function create_pr() {
     export GITHUB_TOKEN="${RELEASE_TOKEN}"
 
     _git commit -a -s -m "${msg}"
-    branch=$(git rev-parse --abbrev-ref HEAD)
+    branch=$(_git rev-parse --abbrev-ref HEAD)
     push_to_repo "${branch}"
     to_review=$(dryrun gh pr create --repo "${ORG}/${project}" --head "${branch}" --base "${base_branch}" --title "${msg}" \
                 --label "automated" --label "ready-to-test" --label "e2e-all-k8s" --body "${msg}" 2>&1)


### PR DESCRIPTION
Branch detection should run in the project directory

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
