### PR TITLE
Apply labels separately on created PRs

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -101,24 +101,28 @@ function push_to_repo() {
 function create_pr() {
     local msg="$1"
     local base_branch="${release['branch']:-devel}"
-    local branch to_review
+    local branch output pr_url
     export GITHUB_TOKEN="${RELEASE_TOKEN}"
 
     _git commit -a -s -m "${msg}"
     branch=$(_git rev-parse --abbrev-ref HEAD)
     push_to_repo "${branch}"
-    to_review=$(dryrun gh pr create --repo "${ORG}/${project}" --head "${branch}" --base "${base_branch}" --title "${msg}" \
-                --label "automated" --label "ready-to-test" --label "e2e-all-k8s" --body "${msg}" 2>&1)
+    output=$(dryrun gh pr create --repo "${ORG}/${project}" --head "${branch}" --base "${base_branch}" --title "${msg}" \
+                --label automated --body "${msg}" 2>&1)
 
     # shellcheck disable=SC2181 # The command is too long already, this is more readable
     if [[ $? -ne 0 ]]; then
-        reviews+=("Error creating pull request to ${msg@Q} on ${project}: ${to_review@Q}")
+        reviews+=("Error creating pull request to ${msg@Q} on ${project}: ${output@Q}")
         return 1
     fi
 
-    to_review=$(echo "${to_review}" | dryrun grep "http.*")
-    dryrun gh pr merge --auto --repo "${ORG}/${project}" --squash "${to_review}" || echo "WARN: Failed to enable auto merge on ${to_review}"
-    reviews+=("${to_review}")
+    pr_url=$(echo "${output}" | dryrun grep "http.*")
+
+    # Apply labels separately, since each label trigger the CI separately anyway and that causes multiple runs clogging the CI up.
+    dryrun gh pr edit --add-label e2e-all-k8s "${pr_url}" || echo "INFO: Didn't label 'e2e-all-k8s', continuing without it."
+    dryrun gh pr edit --add-label ready-to-test "${pr_url}"
+    dryrun gh pr merge --auto --repo "${ORG}/${project}" --squash "${pr_url}" || echo "WARN: Failed to enable auto merge on ${pr_url}"
+    reviews+=("${pr_url}")
 }
 
 function tag_images() {


### PR DESCRIPTION
Apply labels separately, since each label gets applied separately
anyway and that causes multiple runs in the CI, clogging it up.

This should reduce number of false duplicate runs on all repos.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
