### PR TITLE
Consume `ORG` from env, if available

### DIFF
--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -11,8 +11,7 @@ readonly PROJECTS_PROJECTS=(cloud-prepare lighthouse submariner)
 readonly INSTALLER_PROJECTS=(submariner-charts submariner-operator)
 readonly RELEASED_PROJECTS=(subctl)
 
-echo "GITHUB_REPOSITORY_OWNER=${GITHUB_REPOSITORY_OWNER}" >&2
-ORG=${GITHUB_REPOSITORY_OWNER:-$(git config --get remote.origin.url | awk -F'[:/]' '{print $(NF-1)}')}
+ORG=${ORG:-${GITHUB_REPOSITORY_OWNER:-$(git config --get remote.origin.url | awk -F'[:/]' '{print $(NF-1)}')}}
 declare -A NEXT_STATUS=( [branch]=shipyard [shipyard]=admiral [admiral]=projects [projects]=installers [installers]=released )
 
 function printerr() {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,10 +4,12 @@
 set -e
 set -o pipefail
 
-source "${DAPPER_SOURCE}/scripts/lib/utils"
-source "${SCRIPTS_DIR}/lib/debug_functions"
+export ORG="${ORG:-submariner-io}"
 
-ORG=submariner-io
+source "${DAPPER_SOURCE}/scripts/lib/utils"
+source "${SCRIPTS_DIR}/lib/utils"
+print_env ORG GITHUB_ACTOR GITHUB_REPOSITORY_OWNER
+source "${SCRIPTS_DIR}/lib/debug_functions"
 
 ### Functions: General ###
 
@@ -93,7 +95,7 @@ function create_pr() {
 
     # shellcheck disable=SC2046
     project="$(basename $(pwd))"
-    local repo="submariner-io/${project}"
+    local repo="${ORG}/${project}"
     local gh_user=${GITHUB_ACTOR:-${ORG}}
 
     git add "${file}"

--- a/scripts/test/entire-release.sh
+++ b/scripts/test/entire-release.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Always run on "main" org and not on forks that can be stale
-export GITHUB_REPOSITORY_OWNER=submariner-io
+export ORG=submariner-io
 
 source "${DAPPER_SOURCE}/scripts/lib/utils"
 source "${DAPPER_SOURCE}/scripts/test/utils"

--- a/scripts/test/release.sh
+++ b/scripts/test/release.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Always run on "main" org and not on forks that can be stale
-export GITHUB_REPOSITORY_OWNER=submariner-io
+export ORG=submariner-io
 
 source "${DAPPER_SOURCE}/scripts/lib/utils"
 source "${DAPPER_SOURCE}/scripts/test/utils"


### PR DESCRIPTION
Make sure to consume it if available, simplifying and streamlining releasing.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
