### PR TITLE
Fix `Makefile` for subctl compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ ifneq (, $(findstring $(_E2E_CANARY),$(E2E_NEEDED)))
 # TODO: Figure out how to dynamically load correct images
 override PRELOAD_IMAGES=submariner-gateway submariner-route-agent submariner-globalnet submariner-operator
 
-subctl: export DEFAULT_IMAGE_VERSION=devel
-
+# Make sure that for E2E subctl gets compiled with the base branch, or it'll try to deploy images that werent published yet.
+e2e: export DEFAULT_IMAGE_VERSION=$(BASE_BRANCH)
 e2e: deploy
 else
 e2e:


### PR DESCRIPTION
Inadvertently we compiled subctl with devel when E2E is needed (which is true when we release).
We should only override the default version when calling the E2E target, and that gets passed down to the subctl compilation.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
