### PR TITLE
Dry-run call to GH API on validating open PRs

### DIFF
--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -69,7 +69,7 @@ function read_release_file() {
 # Based on global "dryrun" variable
 function dryrun() {
     if [[ "$dryrun" = "true" ]]; then
-        echo DRY RUNNING: "${@:1}"
+        >&2 echo DRY RUNNING: "${@:1}"
         return
     fi
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -130,7 +130,7 @@ function validate_no_update_prs() {
     local update_prs
 
     for project; do
-        if ! update_prs="$(gh_api "pulls?base=${release['branch']:-devel}&head=${ORG}:${head}&state=open" | jq -r ".[].html_url")"; then
+        if ! update_prs="$(dryrun gh_api "pulls?base=${release['branch']:-devel}&head=${ORG}:${head}&state=open" | jq -r ".[].html_url")"; then
             printerr "Failed to list pull requests for ${project}."
             return 1
         fi


### PR DESCRIPTION
With the addition of tests, we're quickly exhausting the rate-limit on GH's API.
To avoid this, dry run the call which checks if any PRs are open while testing.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
