### PR TITLE
Add repository-projects:read to release job token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,10 @@ on:
 
 permissions:
   contents: write
+  issues: write
   packages: write
   pull-requests: write
-  issues: write
+  repository-projects: read
 
 jobs:
   release:


### PR DESCRIPTION
After #470, the release GitHub Action workflow is failing to add labels to PRs.

```
gh pr edit --add-label e2e-all-k8s \
https://github.com/submariner-io/submariner/pull/2032
GraphQL: Your token has not been granted the required scopes to execute
this query. The 'login' field requires one of the following scopes:
['read:org'], but your token has only been granted the:
['admin:repo_hook', 'delete:packages', 'notifications', 'repo',
'workflow', 'write:discussion', 'write:packages'] scopes. Please modify
your token's scopes at: https://github.com/settings/tokens.
INFO: Didn't label 'e2e-all-k8s', continuing without it.
```

The only explination I can find of that permisson is:

> read:org Read org and team membership, read org projects

I can also see that permission is a subset of admin:org. It seems to be different than `read:project Read access of projects` somehow.

It's not clear which GITHUB_TOKEN permisison we can set relates to those token permissions.

docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

It doesn't seem possible set all permissions to read and only some to write, as setting any specific permission overrides read-all.

For now, trying the only permission that seems even vaguely related.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
