### PR TITLE
Stop pretending to run outside dapper container

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -164,15 +164,13 @@ function adjust_shipyard() {
     # Otherwise, image building jobs are likely to fail when creating the branches
     (
         set -e
-
-        # Trick our own Makefile to think we're running outside dapper
-        export DAPPER_HOST_ARCH=""
+        cd projects/shipyard
 
         # Rebuild Shipyard image with the changes we made for stable branches
-        cd projects/shipyard
         make images multiarch-images
 
-        # This will release all of Shipyard's images
+        # This will release all of Shipyard's images (it runs in the "release" container, which is what we want in order to avoid
+        # dapper-in-dapper problems)
         dryrun make release-images TAG="${release['branch']}"
     )
 }


### PR DESCRIPTION
This causes the release to break when it tries to release the images, but we actually don't need this at all and can use the existing "release" container just fine.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
