### PR TITLE
Only pull images for specified versions

### DIFF
--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -14,11 +14,14 @@ function _pull_image() {
 }
 
 function pull_images() {
-    local project_version
+    local project_version=$BASE_BRANCH
     clone_repo
     checkout_project_branch
-    project_version=$(cd "projects/${project}" && make print-version BASE_BRANCH="${release['branch']:-devel}" | \
-                      grep -oP "(?<=CALCULATED_VERSION=).+")
+
+    # Only when a specific image version is requested pull it, otherwise use the default latest for the branch.
+    [[ -z "${release["components.${project}"]}" ]] || \
+        project_version=$(cd "projects/${project}" && make print-version BASE_BRANCH="${release['branch']:-${BASE_BRANCH}}" | \
+                          grep -oP "(?<=CALCULATED_VERSION=).+")
 
     for image in $(project_images); do
         _pull_image "$project_version"


### PR DESCRIPTION
Only pull an image version when a component's version is explicitly requested, otherwise just use the latest for the branch.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
