### PR TITLE
Rebase commits instead of squashing them

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -124,7 +124,7 @@ function create_pr() {
     # Apply labels separately, since each label trigger the CI separately anyway and that causes multiple runs clogging the CI up.
     dryrun gh pr edit --add-label e2e-all-k8s "${pr_url}" || echo "INFO: Didn't label 'e2e-all-k8s', continuing without it."
     dryrun gh pr edit --add-label ready-to-test "${pr_url}"
-    dryrun gh pr merge --auto --repo "${ORG}/${project}" --squash "${pr_url}" || echo "WARN: Failed to enable auto merge on ${pr_url}"
+    dryrun gh pr merge --auto --repo "${ORG}/${project}" --rebase "${pr_url}" || echo "WARN: Failed to enable auto merge on ${pr_url}"
     reviews+=("${pr_url}")
 }
 


### PR DESCRIPTION
Squashing produces commits with remnants of merge commits, rebasing avoids this and leaves only the information we care about.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
