### PR TITLE
Add missing `shipyard-linting` image

### DIFF
--- a/scripts/lib/image_defs
+++ b/scripts/lib/image_defs
@@ -5,6 +5,6 @@ REPO="quay.io/submariner"
 
 declare -A project_images
 project_images[lighthouse]="lighthouse-agent lighthouse-coredns"
-project_images[shipyard]="nettest shipyard-dapper-base"
+project_images[shipyard]="nettest shipyard-dapper-base shipyard-linting"
 project_images[submariner]="submariner-gateway submariner-globalnet submariner-route-agent submariner-networkplugin-syncer"
 project_images[submariner-operator]="submariner-operator submariner-operator-index subctl"


### PR DESCRIPTION
This image is built and shipped by Shipyard but missing from our definitions and hence not being released.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
