### PR TITLE
Run `go mod` updates when testing

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -59,8 +59,12 @@ function clone_and_create_branch() {
 }
 
 function _update_go_mod() {
+    local target_version=${release['branch']:-devel}
+    dryrun target_version="${release['version']}"
+    dryrun export GONOPROXY="github.com/submariner-io/${target}"
+
     go mod tidy -compat=1.17
-    GOPROXY=direct go get "github.com/submariner-io/${target}@${release['version']}"
+    go get "github.com/submariner-io/${target}@${target_version}"
     go mod tidy -compat=1.17
     go mod vendor
 }
@@ -77,7 +81,7 @@ function update_go_mod() {
         fi
 
         # Run in subshell so we don't change the working directory even on failure
-        ( cd "$dir" && dryrun _update_go_mod; )
+        ( cd "$dir" && _update_go_mod; )
     done
 }
 


### PR DESCRIPTION
Right now the dependency updates are being skipped since the versions aren't really being release, but this causes us to miss testing this part of the release process, which could have some stop stopping errors.

This fix will run the updates on the latest stable branch version when we're dry-running, allowing us to validate this part as well.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
