### PR TITLE
Simplify pre-release handling

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,22 +20,27 @@ jobs:
         with:
           paths_ignore: '["releases/**"]'
 
-  release:
-    name: Make release
+  command:
+    name: Command
     needs: skip-check
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        command: ['do-release', 'release']
+
     steps:
       - name: Check out the repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:
           fetch-depth: 0
 
-      - name: Test the `make release` command
+      - name: Test the `make ${{ matrix.command }}` command
         env:
           # Needed for testing as we're running validations which hit the GH API rate limit
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: make test-release
+        run: make test-${{ matrix.command }}
 
   entire-release:
     name: Entire release process

--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -21,12 +21,13 @@ function create_release() {
     local project="$1"
     local target="$2"
     local files=( "${@:3}" )
-    [[ "${release['pre-release']}" = "true" ]] && local prerelease="--prerelease"
-#    [[ -n "${release['release-notes']}" ]] && local notes="--notes ${release['release-notes']}"
+    local prerelease=false
+
+    [[ -z "${semver[pre]}" ]] || prerelease=true
 
     gh config set prompt disabled
-    # shellcheck disable=SC2086,SC2068 # Some things have to be expanded or GH CLI flips out
-    with_retries 3 dryrun gh release create "${release['version']}" ${files[@]} ${prerelease} \
+    with_retries 3 dryrun gh release create "${release['version']}" "${files[@]}" \
+        --prerelease="$prerelease" \
         --title "${release['name']}" \
         --repo "${ORG}/${project}" \
         --target "${target}"

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -57,7 +57,6 @@ function read_release_file() {
 
     _read 'version'
     _read 'name'
-    _read 'pre-release'
     _read 'release-notes'
     _read 'status'
     _read 'branch'

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -118,15 +118,11 @@ version: v${VERSION}
 name: ${VERSION}
 EOF
 
-    if [[ -n "${semver['pre']}" ]]; then
-        write "pre-release: true"
-
-        # On first RC we'll branch to allow development to continue while doing the release
-        if [[ "${semver['pre']}" = "rc0" ]]; then
-            set_stable_branch
-            set_status "branch"
-            return
-        fi
+    # On first RC we'll branch to allow development to continue while doing the release
+    if [[ "${semver['pre']}" = "rc0" ]]; then
+        set_stable_branch
+        set_status "branch"
+        return
     fi
 
     # Detect stable branch and set it if necessary

--- a/scripts/test/do-release.sh
+++ b/scripts/test/do-release.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Always run on "main" org and not on forks that can be stale
+export ORG=submariner-io
+
+source "${DAPPER_SOURCE}/scripts/lib/utils"
+source "${DAPPER_SOURCE}/scripts/test/utils"
+
+### Testing Functions ###
+
+function test_prerelease() {
+    local version="$1"
+    local expected="$2"
+
+    # Generate an appropriate commit that will be picked up and processed by `do-release`
+    yq -n ".version=\"${version}\" | .status=\"shipyard\"" > releases/vtest-prerelease.yaml
+    git add releases/vtest-prerelease.yaml
+    git commit -a -m "Testing pre-release"
+
+    start_test "Testing pre-release for version ${version@Q}, expecting it to be ${expected}."
+    expect_success_running_make do-release
+    expect_make_output_to_contain "gh release create ${version}.* --prerelease=${expected}"
+}
+
+### Main ###
+
+prepare_test_repo
+test_prerelease v100.0.0 false
+test_prerelease v100.0.0-rc0 true
+test_prerelease v100.0.0-m0 true
+

--- a/scripts/test/release.sh
+++ b/scripts/test/release.sh
@@ -59,16 +59,16 @@ function _test_release_step() {
 function test_release() {
     local version="$1"
     local status="$2"
-    local expected_fields=("${@:3}")
+    local branch="$3"
 
     _test_release_step "${version}" "${status}"
 
-    for field in "${expected_fields[@]}"; do
-        expect_in_file "${field}"
-    done
+    if [[ -n "$branch" ]]; then
+        expect_in_file "branch: ${branch}"
 
-    # Since the branch is expected to exist, the script will fail, so remove it for testing
-    VERSION="${version}" sanitize_branch
+        # Since the branch is expected to exist, the script will fail, so remove it for testing
+        VERSION="${version}" sanitize_branch
+    fi
 
     while [[ -n "${NEXT_STATUS[${status}]}" ]]; do
         status="${NEXT_STATUS[${status}]}"
@@ -100,5 +100,5 @@ done
 
 # Test with non-existing branches
 # Only pre-releases are expected to work as we expect RCs or formal releases to happen on a branch (which must exist)
-test_release '100.0.0-m0' 'shipyard' 'pre-release: true'
-test_release '100.0.0-rc0' 'branch' 'branch: release-100.0' 'pre-release: true'
+test_release '100.0.0-m0' 'shipyard'
+test_release '100.0.0-rc0' 'branch' 'release-100.0'

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -157,17 +157,6 @@ function validate_release() {
 
     is_semver "${version#v}" || return 1
 
-    local pre_release="${release['pre-release']}"
-    if [[ "$pre_release" = "true" ]] && [[ ! "$version" =~ -[0-9a-z\.]+$ ]]; then
-        printerr "Version ${version@Q} should have a hyphen followed by identifiers as it's marked as pre-release"
-        return 1
-    fi
-
-    if [[ "$pre_release" != "true" ]] && [[ "$version" =~ - ]]; then
-        printerr "Version ${version@Q} should not have a hyphen as it isn't marked as pre-release"
-        return 1
-    fi
-
     case "${release['status']}" in
     branch)
         for_every_project validate_no_branch "${PROJECTS[@]}"


### PR DESCRIPTION
We're already adressing `${semver[pre]}` in many places to identify a pre-release, making the `pre-release` field unnecessary.

This simplifies the code while maintaining the pre-release functionality.

Depends on #622 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
