### PR TITLE
Use latest RC image as initial GA image

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -148,7 +148,13 @@ function tag_images() {
     local tag=$1
     shift
     local project_version
-    project_version=$(cd "projects/${project}" && make print-version | grep -oP "(?<=CALCULATED_VERSION=).+")
+
+    # Use the latest RC image for the initial GA image, to avoid any potentially breaking changes that might've slipped in untested.
+    if [[ "${semver[patch]}" = "0" && -z "${semver[pre]}" ]]; then
+        project_version=$(git rev-parse --symbolic --tags="v${semver[major]}.${semver[minor]}.*" | sort -V | tail -n1)
+    else
+        project_version=$(cd "projects/${project}" && make print-version | grep -oP "(?<=CALCULATED_VERSION=).+")
+    fi
     
     echo "$QUAY_PASSWORD" | dryrun skopeo login quay.io -u "$QUAY_USERNAME" --password-stdin
     for image; do

--- a/scripts/test/do-release.sh
+++ b/scripts/test/do-release.sh
@@ -10,24 +10,48 @@ source "${DAPPER_SOURCE}/scripts/test/utils"
 
 ### Testing Functions ###
 
-function test_prerelease() {
-    local version="$1"
-    local expected="$2"
+function run_release() {
 
     # Generate an appropriate commit that will be picked up and processed by `do-release`
-    yq -n ".version=\"${version}\" | .status=\"shipyard\"" > releases/vtest-prerelease.yaml
-    git add releases/vtest-prerelease.yaml
-    git commit -a -m "Testing pre-release"
+    yq -n ".version=\"${version}\" | .status=\"shipyard\"" > releases/vtest-do-release.yaml
+    git add releases/vtest-do-release.yaml
+    git commit -a -m "Testing do-release"
 
-    start_test "Testing pre-release for version ${version@Q}, expecting it to be ${expected}."
+    start_test "Testing do-release for version ${version@Q}."
     expect_success_running_make do-release
+}
+
+function expect_prerelease() {
+    local expected="$1"
     expect_make_output_to_contain "gh release create ${version}.* --prerelease=${expected}"
+}
+
+function expect_image_tagging() {
+    local expected="${1:-${BASE_BRANCH}-[[:xdigit:]]*}"
+    expect_make_output_to_contain "skopeo copy .*/shipyard-dapper-base:${expected} .*/shipyard-dapper-base:${version#v}$"
 }
 
 ### Main ###
 
 prepare_test_repo
-test_prerelease v100.0.0 false
-test_prerelease v100.0.0-rc0 true
-test_prerelease v100.0.0-m0 true
+git tag -f v100.0.0-rc999
 
+version=v100.0.0
+run_release
+expect_prerelease false
+expect_image_tagging 100.0.0-rc999
+
+version=v100.0.0-rc0
+run_release
+expect_prerelease true
+expect_image_tagging
+
+version=v100.0.0-m0
+run_release
+expect_prerelease true
+expect_image_tagging
+
+version=v100.0.1
+run_release
+expect_prerelease false
+expect_image_tagging


### PR DESCRIPTION
In case we're releasing the first GA, use the latest (RC) image which has been thoroughly validated during a test day, instead of relying on a rebuilt image which might've introduced unforeseen issues.

Depends on #617 

Resolves #335 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
