### PR TITLE
Mark latest release when the release is latest

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -21,12 +21,18 @@ function create_release() {
     local project="$1"
     local target="$2"
     local files=( "${@:3}" )
+    local version="${release[version]}"
+    local latest=false
     local prerelease=false
 
     [[ -z "${semver[pre]}" ]] || prerelease=true
 
+    # Mark as latest release only when we're actually trying to release the latest GA release (ignoring any pre-releases).
+    [[ $({ echo "$version"; git tag -l 'v*'; } | grep -v '-' | sort -V | tail -n1) != "$version" ]] || latest=true
+
     gh config set prompt disabled
-    with_retries 3 dryrun gh release create "${release['version']}" "${files[@]}" \
+    with_retries 3 dryrun gh release create "$version" "${files[@]}" \
+        --latest="$latest" \
         --prerelease="$prerelease" \
         --title "${release['name']}" \
         --repo "${ORG}/${project}" \

--- a/scripts/test/do-release.sh
+++ b/scripts/test/do-release.sh
@@ -19,6 +19,9 @@ function run_release() {
 
     start_test "Testing do-release for version ${version@Q}."
     expect_success_running_make do-release
+
+    # Simulate the tag being created, for any operation that relies on it
+    git tag -f "$version"
 }
 
 function expect_prerelease() {
@@ -31,27 +34,49 @@ function expect_image_tagging() {
     expect_make_output_to_contain "skopeo copy .*/shipyard-dapper-base:${expected} .*/shipyard-dapper-base:${version#v}$"
 }
 
+function expect_latest() {
+    local expected="$1"
+    expect_make_output_to_contain "gh release create ${version}.* --latest=${expected}"
+}
+
 ### Main ###
 
 prepare_test_repo
-git tag -f v100.0.0-rc999
+git tag -f v99.0.0
 
-version=v100.0.0
+# New version while "devel" is still not officially released should be latest
+version=v99.0.1
 run_release
 expect_prerelease false
-expect_image_tagging 100.0.0-rc999
-
-version=v100.0.0-rc0
-run_release
-expect_prerelease true
-expect_image_tagging
+expect_latest true
 
 version=v100.0.0-m0
 run_release
 expect_prerelease true
+expect_latest false
 expect_image_tagging
 
+version=v100.0.0-rc0
+run_release
+expect_prerelease true
+expect_latest false
+expect_image_tagging
+
+version=v100.0.0
+run_release
+expect_prerelease false
+expect_latest true
+expect_image_tagging 100.0.0-rc0
+
+# New "stable" release shouldn't be marked as latest, as an even newer GA exists
+version=v99.0.2
+run_release
+expect_prerelease false
+expect_latest false
+
+# New GA for latest "stable" release should be marked latest
 version=v100.0.1
 run_release
 expect_prerelease false
+expect_latest true
 expect_image_tagging


### PR DESCRIPTION
To avoid confusion when releasing older stable branches, make sure to mark as "latest" only when releasing on the latest stable branch.

Depends on #624 

Resolves #573

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
