### PR TITLE
Fix dryrun call for `go.mod` updates

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -69,7 +69,7 @@ function clone_and_create_branch() {
 function _update_go_mod() {
     [[ -z "$SKIP_WHEN_TESTING" ]] || { echo "SKIPPING: ${FUNCNAME[0]}" && return 0; }
     local target_version=${release['branch']:-devel}
-    dryrun target_version="${release['version']}"
+    dryrun eval target_version="${release['version']}"
     dryrun export GONOPROXY="github.com/submariner-io/${target}"
 
     go mod tidy -compat=1.17


### PR DESCRIPTION
Seems its not possible to run a simple variable assignment (export is fine though), so we need to use `eval` for it.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
