### PR TITLE
Skip comment only on success

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -274,15 +274,12 @@ function release_released() {
 }
 
 function comment_finished_status() {
-    if [[ ${#reviews[@]} = 0 ]]; then
-        return
-    fi
-
     local comment="Release for status '${release['status']}' finished "
 
     if [[ $errors -gt 0 ]]; then
         comment+=$(printf "%s\n%s" "with ${errors} errors." "Please check the job for more details: ${GITHUB_JOB_URL}")
     else
+        [[ ${#reviews[@]} -gt 0 ]] || return 0
         comment+="successfully. Please review:"
         for review in "${reviews[@]}"; do
             comment+=$(printf "\n * %s" "${review}")


### PR DESCRIPTION
When we fail we want to comment that the release failed. Skip commenting only on success when there's no PRs to review.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
