### PR TITLE
Use `exit_error` in all scripts

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -237,7 +237,7 @@ function release_admiral() {
 function update_operator_versions() {
     local versions_file
     versions_file=$(grep -l -r --include='*.go' --exclude-dir=vendor 'Default.*Version *=' "projects/${project}/")
-    [[ -n "${versions_file}" ]] || { printerr "Can't find file for default image versions"; return 1; }
+    [[ -n "${versions_file}" ]] || exit_error "Can't find file for default image versions"
 
     sed -i -E "s/(Default.*Version *=) .*/\1 \"${release['version']#v}\"/" "${versions_file}"
 }
@@ -303,14 +303,9 @@ branch|shipyard|admiral|projects|installers|released)
     "release_${release['status']}"
     ;;
 *)
-    printerr "Unknown status '${release['status']}'"
-    exit 1
+    exit_error "Unknown status '${release['status']}'"
     ;;
 esac
 
 comment_finished_status || echo "WARN: Can't post comment with release status"
-
-if [[ $errors -gt 0 ]]; then
-    printerr "Encountered ${errors} errors while doing the release."
-    exit 1
-fi
+[[ $errors -eq 0 ]] || exit_error "Encountered ${errors} errors while doing the release."

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -15,11 +15,13 @@ ORG=${ORG:-${GITHUB_REPOSITORY_OWNER:-$(git config --get remote.origin.url | awk
 declare -A NEXT_STATUS=( [branch]=shipyard [shipyard]=admiral [admiral]=projects [projects]=installers [installers]=released )
 
 function printerr() {
-    local DEBUG_PRINT=false
-    local err_msg="$*"
+    >&2 echo "ERROR: $*"
+}
 
-    [[ -z "${file}" ]] || err_msg+=" (${file})"
-    printf "ERROR: %s\n" "${err_msg}" >&2
+function exit_error() {
+    local DEBUG_PRINT=false
+    printerr "$*"
+    exit 1
 }
 
 function count_parents() {
@@ -107,14 +109,11 @@ function checkout_project_branch() {
     _git checkout "${branch}"
 }
 
-function is_semver() {
+function validate_semver() {
     local DEBUG_PRINT=false
     local ver="(0|[1-9][0-9]*)"
     local regex="^${ver}\.${ver}\.${ver}(-([0-9a-zA-Z.-]*))?$"
-    if [[ ! "$1" =~ ${regex} ]]; then
-        printerr "Version ${1@Q} is not a valid semantic version"
-        return 1
-    fi
+    [[ "$1" =~ ${regex} ]] || exit_error "Version ${1@Q} is not a valid semantic version"
 }
 
 function extract_semver() {

--- a/scripts/test/utils
+++ b/scripts/test/utils
@@ -8,11 +8,6 @@ readonly TEST_DIR=projects/releases
 
 ### General Functions ###
 
-function exit_error() {
-    echo "ERROR: $*"
-    exit 1
-}
-
 function start_test() {
     [[ -z "$CI" ]] || { printf '::endgroup::\n::group::%s\n' "$*" && return 0; }
     local div=${*//?/=}


### PR DESCRIPTION
The function is moved from test utils to general utils in order to be used in all scripts.

The `printerr` function is simplified as we're only handling one release file at a time, and hence there's no need to add the file information.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
