### PR TITLE
Use `Depends on <update PR>` when creating release

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -3,6 +3,8 @@ name: Validation
 
 on:
   pull_request:
+    # Unlabeled is needed when `dependent` label is removed, to re-validate the release.
+    types: [unlabeled, opened, synchronize, reopened]
 
 permissions: {}
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -116,19 +116,6 @@ function validate_project_commits() {
     done
 }
 
-function validate_no_update_prs() {
-    local head="update-dependencies-${release['branch']:-devel}"
-    local update_prs
-
-    for project; do
-        update_prs="$(dryrun gh_api "pulls?base=${release['branch']:-devel}&head=${ORG}:${head}&state=open" | jq -r ".[].html_url")" || \
-            exit_error "Failed to list pull requests for ${project}."
-
-        [[ -z "${update_prs}" ]] || \
-            exit_error "Found open ${head@Q} pull requests on ${project}, make sure they're merged before proceeding:"$'\n'"$update_prs"
-    done
-}
-
 function validate_release() {
     local version="${release['version']}"
     validate_release_fields || exit_error "File is missing expected fields"
@@ -145,19 +132,15 @@ function validate_release() {
         ;;
     admiral)
         validate_project_commits admiral
-        validate_no_update_prs "${SHIPYARD_CONSUMERS[@]}"
         ;;
     projects)
         validate_project_commits "${PROJECTS_PROJECTS[@]}"
-        validate_no_update_prs "${ADMIRAL_CONSUMERS[@]}"
         ;;
     installers)
         validate_project_commits "${INSTALLER_PROJECTS[@]}"
-        validate_no_update_prs "${INSTALLER_PROJECTS[@]}"
         ;;
     released)
         validate_project_commits "${RELEASED_PROJECTS[@]}"
-        validate_no_update_prs "${RELEASED_PROJECTS[@]}"
         ;;
     esac
 


### PR DESCRIPTION
Instead of validating no update PRs are still open, utilize our use of dependency checks to have the created release PR depend on the open PRs. Once all PRs are merged, the project SHAs can be updated and the PR can proceed.

Resolves #457 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
