### PR TITLE
Create submariner-charts release tag in released phase

### DIFF
--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -8,8 +8,8 @@ readonly SHIPYARD_CONSUMERS=(admiral lighthouse subctl submariner submariner-ope
 readonly OPERATOR_CONSUMES=(submariner lighthouse)
 readonly SUBCTL_CONSUMES=(submariner submariner-operator cloud-prepare lighthouse)
 readonly PROJECTS_PROJECTS=(cloud-prepare lighthouse submariner)
-readonly INSTALLER_PROJECTS=(submariner-charts submariner-operator)
-readonly RELEASED_PROJECTS=(subctl)
+readonly INSTALLER_PROJECTS=(submariner-operator)
+readonly RELEASED_PROJECTS=(subctl submariner-charts)
 
 ORG=${ORG:-${GITHUB_REPOSITORY_OWNER:-$(git config --get remote.origin.url | awk -F'[:/]' '{print $(NF-1)}')}}
 declare -A NEXT_STATUS=( [branch]=shipyard [shipyard]=admiral [admiral]=projects [projects]=installers [installers]=released )

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -145,7 +145,7 @@ function advance_to_installers() {
 }
 
 function advance_to_released() {
-    write_component "subctl"
+  for_every_project write_component "${RELEASED_PROJECTS[@]}"
 }
 
 function update_prs_message() {


### PR DESCRIPTION
The submariner-charts PR to update the `CHARTS_VERSION` is created in the installers phase but after the release tag is created. To fix this, remove submariner-charts from `INSTALLER_PROJECTS` so it is created in the released phase.
