### PR TITLE
Backport of #726 and #736

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -272,6 +272,11 @@ function release_installers() {
     # Create a PR for subctl to use these versions
     local project="subctl"
     record_errors update_dependencies Subctl "${SUBCTL_CONSUMES[@]}"
+
+    # Create a PR in submariner-charts to update the CHARTS_VERSION in the Makefile
+    local project="submariner-charts"
+    local update_dependencies_extra=update_charts_versions
+    record_errors update_dependencies Charts
 }
 
 ### Functions: Released Stage ###
@@ -283,6 +288,10 @@ function release_released() {
     record_errors create_release releases "${commit_ref}" projects/subctl/dist/subctl-*
 
     for_every_project create_project_release "${PROJECTS[@]}"
+}
+
+function update_charts_versions() {
+     sed -i -E "s/(CHARTS_VERSION=).*/\1${release['version']#v}/" projects/"${project}"/Makefile
 }
 
 function comment_finished_status() {

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -8,8 +8,8 @@ readonly SHIPYARD_CONSUMERS=(admiral lighthouse subctl submariner submariner-ope
 readonly OPERATOR_CONSUMES=(submariner lighthouse)
 readonly SUBCTL_CONSUMES=(submariner submariner-operator cloud-prepare lighthouse)
 readonly PROJECTS_PROJECTS=(cloud-prepare lighthouse submariner)
-readonly INSTALLER_PROJECTS=(submariner-charts submariner-operator)
-readonly RELEASED_PROJECTS=(subctl)
+readonly INSTALLER_PROJECTS=(submariner-operator)
+readonly RELEASED_PROJECTS=(subctl submariner-charts)
 
 ORG=${ORG:-${GITHUB_REPOSITORY_OWNER:-$(git config --get remote.origin.url | awk -F'[:/]' '{print $(NF-1)}')}}
 declare -A NEXT_STATUS=( [branch]=shipyard [shipyard]=admiral [admiral]=projects [projects]=installers [installers]=released )

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -145,7 +145,7 @@ function advance_to_installers() {
 }
 
 function advance_to_released() {
-    write_component "subctl"
+  for_every_project write_component "${RELEASED_PROJECTS[@]}"
 }
 
 function update_prs_message() {


### PR DESCRIPTION
Backport of:

https://github.com/submariner-io/releases/pull/726: Update submariner-charts version during the installers phase
https://github.com/submariner-io/releases/pull/736: Create submariner-charts release tag in released phase

on release-0.15.
