### PR TITLE
Bump all dependencies in one go

### DIFF
--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -3,10 +3,6 @@
 
 readonly PROJECTS=(admiral cloud-prepare lighthouse shipyard subctl submariner submariner-charts submariner-operator)
 readonly REPO="quay.io/submariner"
-readonly ADMIRAL_CONSUMERS=(cloud-prepare lighthouse subctl submariner submariner-operator)
-readonly SHIPYARD_CONSUMERS=(admiral lighthouse subctl submariner submariner-operator)
-readonly OPERATOR_CONSUMES=(submariner lighthouse)
-readonly SUBCTL_CONSUMES=(submariner submariner-operator cloud-prepare lighthouse)
 readonly PROJECTS_PROJECTS=(cloud-prepare lighthouse submariner)
 readonly INSTALLER_PROJECTS=(submariner-operator)
 readonly RELEASED_PROJECTS=(subctl submariner-charts)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -151,10 +151,10 @@ function advance_to_released() {
 function update_prs_message() {
     case "$1" in
     admiral)
-        print_update_prs "${SHIPYARD_CONSUMERS[@]}"
+        print_update_prs "$1"
         ;;
     projects)
-        print_update_prs "${ADMIRAL_CONSUMERS[@]}"
+        print_update_prs "${PROJECTS_PROJECTS[@]}"
         ;;
     installers)
         print_update_prs "${INSTALLER_PROJECTS[@]}"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -74,7 +74,7 @@ function validate_release_fields() {
 
 function validate_admiral_consumers() {
     local expected_version="$1"
-    for project in "${ADMIRAL_CONSUMERS[@]}"; do
+    for project in "${PROJECTS_PROJECTS[@]}"; do
         local actual_version
         actual_version=$(grep admiral "projects/${project}/go.mod" | cut -f2 -d' ')
         if [[ "${expected_version}" != "${actual_version}" ]]; then
@@ -86,14 +86,13 @@ function validate_admiral_consumers() {
 
 function validate_shipyard_consumers() {
     local expected_version="$1"
-    for project in "${SHIPYARD_CONSUMERS[@]}"; do
-        local actual_version
-        actual_version=$(head -1 "projects/${project}/Dockerfile.dapper" | cut -f2 -d':')
-        if [[ "${expected_version}" != "${actual_version}" ]]; then
-            printerr "Expected Shipyard version ${expected_version} but found ${actual_version} in ${project}"
-            return 1
-        fi
-    done
+    local project=admiral
+    local actual_version
+    actual_version=$(head -1 "projects/${project}/Dockerfile.dapper" | cut -f2 -d':')
+    if [[ "${expected_version}" != "${actual_version}" ]]; then
+        printerr "Expected Shipyard version ${expected_version} but found ${actual_version} in ${project}"
+        return 1
+    fi
 }
 
 function validate_no_branch() {


### PR DESCRIPTION
Instead of trickling down dependency bumps, this applies all dependency upgrades in a single PR per project. This doesn't change anything for shipyard; then:
* once shipyard is released, only admiral is upgraded
* once admiral is released, cloud-prepare, lighthouse and submariner are upgraded (with the new releases of both shipyard and admiral)
* once cloud-prepare, lighthouse, and submariner are released, submariner-operator is upgraded
* once submariner-operator is released, subctl is upgraded

This reduces the overall number of PRs needed for a release, and ensures that each project gets a consistent set of upgrades (avoiding breakage related e.g. to API changes in one project requiring simultaneous upgrades of all affected dependencies in the operator or subctl).

Fixes: #671

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
