### PR TITLE
Automated backport of #767: Split the “Components:” header off

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -189,7 +189,7 @@ function print_component_links {
         fi
     done
 
-    [[ ${#component_links[@]} -eq 0 ]] || printf 'Components:\n%s\n' "${component_links[@]}"
+    [[ ${#component_links[@]} -eq 0 ]] || { echo Components:; printf '%s\n' "${component_links[@]}"; }
 }
 
 function advance_stage() {


### PR DESCRIPTION
Backport of #767 on release-0.15.

#767: Split the “Components:” header off

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.