### PR TITLE
Advancing 0.15.2 release to status: installers

### DIFF
--- a/releases/v0.15.2.yaml
+++ b/releases/v0.15.2.yaml
@@ -2,10 +2,11 @@
 version: v0.15.2
 name: 0.15.2
 branch: release-0.15
-status: projects
+status: installers
 components:
   shipyard: 95e8f41ab7c630ced095cf5d426517373f0812ba
   admiral: 2cbb49a6ac70dae15f36d7c00207d47933ad0bd1
   cloud-prepare: e8d7d01ef99048e8a6322ca4675678dd6a27dd31
   lighthouse: a63289692af99180cc9c371de2ed9721501e0074
   submariner: ec971891f7221c971d96af7b9f95f9763dac75b3
+  submariner-operator: a045fc2e99f1469770a3ca6b9f6430a356c710a6


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.15
Components:
* https://github.com/submariner-io/cloud-prepare/commits/release-0.15
Components:
* https://github.com/submariner-io/lighthouse/commits/release-0.15
Components:
* https://github.com/submariner-io/shipyard/commits/release-0.15
Components:
* https://github.com/submariner-io/submariner/commits/release-0.15
Components:
* https://github.com/submariner-io/submariner-operator/commits/release-0.15