### PR TITLE
Advancing 0.16.0-m2 release to status: released

### DIFF
--- a/releases/v0.16.0-m2.yaml
+++ b/releases/v0.16.0-m2.yaml
@@ -1,7 +1,7 @@
 ---
 version: v0.16.0-m2
 name: 0.16.0-m2
-status: installers
+status: released
 components:
   shipyard: 539fcfe05e099638d2c2bd7781b1b8b382bcb95e
   admiral: dce26687e81835d830d0bac3c3577b268b26824f
@@ -9,3 +9,5 @@ components:
   lighthouse: f02dfad9494a47ddb48470bd324616191c1093f6
   submariner: 9c64b9129fa737a12f01961151cceb8cdaad9127
   submariner-operator: 9265610ed46116100b344dc54cdd8663d88de525
+  subctl: 7970fcfdfe0ce496e0bddcf7b2c9a4688b8c4f64
+  submariner-charts: b5159cbb5c7f79d3ecd5e9213b16439763c74cb0


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/devel
* https://github.com/submariner-io/cloud-prepare/commits/devel
* https://github.com/submariner-io/lighthouse/commits/devel
* https://github.com/submariner-io/shipyard/commits/devel
* https://github.com/submariner-io/subctl/commits/devel
* https://github.com/submariner-io/submariner/commits/devel
* https://github.com/submariner-io/submariner-charts/commits/devel
* https://github.com/submariner-io/submariner-operator/commits/devel