### PR TITLE
Advancing 0.16.0-rc0 release to status: shipyard

### DIFF
--- a/releases/v0.16.0-rc0.yaml
+++ b/releases/v0.16.0-rc0.yaml
@@ -2,4 +2,6 @@
 version: v0.16.0-rc0
 name: 0.16.0-rc0
 branch: release-0.16
-status: branch
+status: shipyard
+components:
+  shipyard: 9e634a783fe767bf4e55a3d48b72822bbb2e5c30


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/shipyard/commits/release-0.16