### PR TITLE
Advancing 0.16.0-rc0 release to status: released

### DIFF
--- a/releases/v0.16.0-rc0.yaml
+++ b/releases/v0.16.0-rc0.yaml
@@ -2,7 +2,7 @@
 version: v0.16.0-rc0
 name: 0.16.0-rc0
 branch: release-0.16
-status: installers
+status: released
 components:
   shipyard: 9e634a783fe767bf4e55a3d48b72822bbb2e5c30
   admiral: 898b7b6b12bf0a49b2854beb6b0e0523cf90b27e
@@ -10,3 +10,5 @@ components:
   lighthouse: ace4afb87aad4c6393fb3714a7d3a79a34798597
   submariner: 2f594c6eb2ecdbd1e7fb915da5ddef003f6a0365
   submariner-operator: 571e2ce96f15f8710e981c25db7d1a9e1ad8e35a
+  subctl: a7fa679e72363fb26012588d3e420bdf9cf15dea
+  submariner-charts: 353261f2e7788bdf6c5144348a30754384564ac8


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.16
* https://github.com/submariner-io/cloud-prepare/commits/release-0.16
* https://github.com/submariner-io/lighthouse/commits/release-0.16
* https://github.com/submariner-io/shipyard/commits/release-0.16
* https://github.com/submariner-io/subctl/commits/release-0.16
* https://github.com/submariner-io/submariner/commits/release-0.16
* https://github.com/submariner-io/submariner-charts/commits/release-0.16
* https://github.com/submariner-io/submariner-operator/commits/release-0.16