### PR TITLE
Advancing 0.16.0 release to status: admiral

### DIFF
--- a/releases/v0.16.0.yaml
+++ b/releases/v0.16.0.yaml
@@ -2,6 +2,7 @@
 version: v0.16.0
 name: 0.16.0
 branch: release-0.16
-status: shipyard
+status: admiral
 components:
   shipyard: 642049ac1e12644520afad988c1cb478323c96fd
+  admiral: 8a5bb5bb09f6605086fdc830e909ba4ce4f19485


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.16
* https://github.com/submariner-io/shipyard/commits/release-0.16