### PR TITLE
Advancing 0.16.0 release to status: installers

### DIFF
--- a/releases/v0.16.0.yaml
+++ b/releases/v0.16.0.yaml
@@ -2,10 +2,11 @@
 version: v0.16.0
 name: 0.16.0
 branch: release-0.16
-status: projects
+status: installers
 components:
   shipyard: 642049ac1e12644520afad988c1cb478323c96fd
   admiral: 8a5bb5bb09f6605086fdc830e909ba4ce4f19485
   cloud-prepare: f4b93a22ce5c0d49037474cc2d6f462eb64989e0
   lighthouse: f96ebab2cd03a1b113cce14f59296617026ed3ba
   submariner: be60343e0edc980347666d32272bd136409dd19b
+  submariner-operator: c8ec8d075914d068c17c0c9ff868160ab670e28a


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.16
* https://github.com/submariner-io/cloud-prepare/commits/release-0.16
* https://github.com/submariner-io/lighthouse/commits/release-0.16
* https://github.com/submariner-io/shipyard/commits/release-0.16
* https://github.com/submariner-io/submariner/commits/release-0.16
* https://github.com/submariner-io/submariner-operator/commits/release-0.16