### PR TITLE
Advancing 0.15.3 release to status: released

### DIFF
--- a/releases/v0.15.3.yaml
+++ b/releases/v0.15.3.yaml
@@ -2,7 +2,7 @@
 version: v0.15.3
 name: 0.15.3
 branch: release-0.15
-status: installers
+status: released
 components:
   shipyard: 238a4dc1e5b0949780dcf91be2f9e5c80f8d63bb
   admiral: a1623fea64d116e31cdd5e5d189264312c8f598f
@@ -10,3 +10,5 @@ components:
   lighthouse: 6d5ea5e3652a1223d3fef028cf756cd13db546c5
   submariner: 5f0c88e45cbfe98f39d0425f2eda4e79649224f4
   submariner-operator: 79d0cdd2385115268ffdca9d6644fd73408d4d85
+  subctl: 44794b4bb9b17762e39fe361eb9b17eb07efec79
+  submariner-charts: ac5b4c5437e56e07b418b3502dc141f8e3e8d7ca


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.15
* https://github.com/submariner-io/cloud-prepare/commits/release-0.15
* https://github.com/submariner-io/lighthouse/commits/release-0.15
* https://github.com/submariner-io/shipyard/commits/release-0.15
* https://github.com/submariner-io/subctl/commits/release-0.15
* https://github.com/submariner-io/submariner/commits/release-0.15
* https://github.com/submariner-io/submariner-charts/commits/release-0.15
* https://github.com/submariner-io/submariner-operator/commits/release-0.15