### PR TITLE
Advancing 0.16.1 release to status: released

### DIFF
--- a/releases/v0.16.1.yaml
+++ b/releases/v0.16.1.yaml
@@ -2,7 +2,7 @@
 version: v0.16.1
 name: 0.16.1
 branch: release-0.16
-status: installers
+status: released
 components:
   shipyard: 078f5a9ee1d3da5e6bed13e3ffd372da138f4cbc
   admiral: 255fd2823b41c2fafa8214aa192527aaf103c771
@@ -10,3 +10,5 @@ components:
   lighthouse: 8c0d3791b7553111549edb3fed4fd2fcc9bda9f9
   submariner: 1afe7e6dc305366cd4c532ae66ab07709c56b78f
   submariner-operator: 5e43e25aad9651ee9a22cfdb0aea738ede3d064e
+  subctl: 2b5fa5827488517a2a9fbb80e9560716682843e0
+  submariner-charts: ece52e9f15d61fa91dc9c1f2dc71ae9216d970a8


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.16
* https://github.com/submariner-io/cloud-prepare/commits/release-0.16
* https://github.com/submariner-io/lighthouse/commits/release-0.16
* https://github.com/submariner-io/shipyard/commits/release-0.16
* https://github.com/submariner-io/subctl/commits/release-0.16
* https://github.com/submariner-io/submariner/commits/release-0.16
* https://github.com/submariner-io/submariner-charts/commits/release-0.16
* https://github.com/submariner-io/submariner-operator/commits/release-0.16