### PR TITLE
Advancing 0.17.0-rc0 release to status: installers

### DIFF
--- a/releases/v0.17.0-rc0.yaml
+++ b/releases/v0.17.0-rc0.yaml
@@ -2,10 +2,11 @@
 version: v0.17.0-rc0
 name: 0.17.0-rc0
 branch: release-0.17
-status: projects
+status: installers
 components:
   shipyard: a8a0e4cda0b1c8bfeb997d090fe0d88d3b3d8bb2
   admiral: eb9dfbd134d0111cf3ffb04981d35edb0d4874e9
   cloud-prepare: 21690ca716a33d6205691e105d478b3b5bd0ca50
   lighthouse: 7d0ebca9411fa72b20ceb65f4bb7e816a668fd14
   submariner: c310c7fd8301775ec357217e97a1f142439d0d45
+  submariner-operator: 096f17dd3c2cbea245cf1345da748f78af2156fb


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.17
* https://github.com/submariner-io/cloud-prepare/commits/release-0.17
* https://github.com/submariner-io/lighthouse/commits/release-0.17
* https://github.com/submariner-io/shipyard/commits/release-0.17
* https://github.com/submariner-io/submariner/commits/release-0.17
* https://github.com/submariner-io/submariner-operator/commits/release-0.17