### PR TITLE
Fix update krew-index job

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -3,9 +3,8 @@ name: Post Release
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types: [published]
 
 jobs:
   update-krew:
@@ -13,6 +12,10 @@ jobs:
     if: github.repository_owner == 'submariner-io'
     runs-on: ubuntu-latest
     steps:
+      - name: Check out the repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        with:
+          fetch-depth: 0
       - name: Get the latest release tag
         run: |
           RELEASE_JSON=$(curl -L \


### PR DESCRIPTION
- The job did not get triggered when the **0.17.1** release was created. We were using the "_on push tags_" event trigger however this seems to apply if `git push` is used. We actually use `gh release create` so we need to use the "_on release published_" event trigger (I verified this works via a test job on my fork).

- The `krew-release-bot` action failed b/c it could not find our _.krew.yaml_ file. We need to first check out the **releases** repository.