### PR TITLE
Backport of #963: Fix update krew-index job

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -3,9 +3,8 @@ name: Post Release
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types: [published]
 
 jobs:
   update-krew:
@@ -13,6 +12,10 @@ jobs:
     if: github.repository_owner == 'submariner-io'
     runs-on: ubuntu-latest
     steps:
+      - name: Check out the repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        with:
+          fetch-depth: 0
       - name: Get the latest release tag
         run: |
           RELEASE_JSON=$(curl -L \


### PR DESCRIPTION
Backport of https://github.com/submariner-io/releases/pull/963 on release-0.17.
