### PR TITLE
Advancing 0.18.0-rc0 release to status: shipyard

### DIFF
--- a/releases/v0.18.0-rc0.yaml
+++ b/releases/v0.18.0-rc0.yaml
@@ -2,4 +2,6 @@
 version: v0.18.0-rc0
 name: 0.18.0-rc0
 branch: release-0.18
-status: branch
+status: shipyard
+components:
+  shipyard: 5e5dd79c025807c7b269c5acf2ccbe665ee25836


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/shipyard/commits/release-0.18