### PR TITLE
Advancing 0.18.0-rc0 release to status: installers

### DIFF
--- a/releases/v0.18.0-rc0.yaml
+++ b/releases/v0.18.0-rc0.yaml
@@ -2,10 +2,11 @@
 version: v0.18.0-rc0
 name: 0.18.0-rc0
 branch: release-0.18
-status: projects
+status: installers
 components:
   shipyard: 5e5dd79c025807c7b269c5acf2ccbe665ee25836
   admiral: a9ec992cf8756b12073e0ad17b1e34d1ae5de1d1
   cloud-prepare: 8eb36d4f31844aea804ad8f3a65cd0b418263513
   lighthouse: 85c186b338e2c7b39911642d4798c1aeda1c2d69
   submariner: 85f6d321b61373b9ae9103d958bc52135cef95ea
+  submariner-operator: 460a4d25ae29042ee75c3c0ecd3aafbc8c37e141


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.18
* https://github.com/submariner-io/cloud-prepare/commits/release-0.18
* https://github.com/submariner-io/lighthouse/commits/release-0.18
* https://github.com/submariner-io/shipyard/commits/release-0.18
* https://github.com/submariner-io/submariner/commits/release-0.18
* https://github.com/submariner-io/submariner-operator/commits/release-0.18