### PR TITLE
Advancing 0.16.7 release to status: installers

### DIFF
--- a/releases/v0.16.7.yaml
+++ b/releases/v0.16.7.yaml
@@ -2,10 +2,11 @@
 version: v0.16.7
 name: 0.16.7
 branch: release-0.16
-status: projects
+status: installers
 components:
   shipyard: 5696bd9497c6fb68aa5c71e4d26ec74125c5ff3a
   admiral: 70e41f534f5c1724900663e18bba8da0d1cfb2e2
   cloud-prepare: 83ae6471bcde0ee4a7cb56be688dfd7f8a28fb64
   lighthouse: d70b6ceed6e1ed211bef3f9d1a4163d5083d17a5
   submariner: 8b7daf66a16912d396c9c4c3062e1c8e07607d49
+  submariner-operator: d4530ae1ad424b673305a574474b18b33f468ecf


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.16
* https://github.com/submariner-io/cloud-prepare/commits/release-0.16
* https://github.com/submariner-io/lighthouse/commits/release-0.16
* https://github.com/submariner-io/shipyard/commits/release-0.16
* https://github.com/submariner-io/submariner/commits/release-0.16
* https://github.com/submariner-io/submariner-operator/commits/release-0.16