### PR TITLE
Advancing 0.18.0 release to status: installers

### DIFF
--- a/releases/v0.18.0.yaml
+++ b/releases/v0.18.0.yaml
@@ -2,10 +2,11 @@
 version: v0.18.0
 name: 0.18.0
 branch: release-0.18
-status: projects
+status: installers
 components:
   shipyard: 011349c6f17e8cbd2693645a4662e43cfa84341a
   admiral: bcb4f04986a22822a54aa4736717f217a2187190
   cloud-prepare: 5f5833cb507e0b7556bb4d92426dc27ba1323d9e
   lighthouse: d3528c49dbad3b7dc00d71f436cb7ea430ca5bd0
   submariner: 3b035f14d6f88f3edb2f2676893edf05f3e0dc27
+  submariner-operator: 0fe6e2d13cb157a1e3bbcaeefdf31fc8943980d8


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.18
* https://github.com/submariner-io/cloud-prepare/commits/release-0.18
* https://github.com/submariner-io/lighthouse/commits/release-0.18
* https://github.com/submariner-io/shipyard/commits/release-0.18
* https://github.com/submariner-io/submariner/commits/release-0.18
* https://github.com/submariner-io/submariner-operator/commits/release-0.18