### PR TITLE
Advancing 0.18.0 release to status: released

### DIFF
--- a/releases/v0.18.0.yaml
+++ b/releases/v0.18.0.yaml
@@ -2,7 +2,7 @@
 version: v0.18.0
 name: 0.18.0
 branch: release-0.18
-status: installers
+status: released
 components:
   shipyard: 011349c6f17e8cbd2693645a4662e43cfa84341a
   admiral: bcb4f04986a22822a54aa4736717f217a2187190
@@ -10,3 +10,5 @@ components:
   lighthouse: d3528c49dbad3b7dc00d71f436cb7ea430ca5bd0
   submariner: 3b035f14d6f88f3edb2f2676893edf05f3e0dc27
   submariner-operator: 0fe6e2d13cb157a1e3bbcaeefdf31fc8943980d8
+  subctl: 9e8153330a530fbb65be77e7bea5fd60049849a6
+  submariner-charts: 30728cdf7c9f5a36cb3641577926baad5aa553b1


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.18
* https://github.com/submariner-io/cloud-prepare/commits/release-0.18
* https://github.com/submariner-io/lighthouse/commits/release-0.18
* https://github.com/submariner-io/shipyard/commits/release-0.18
* https://github.com/submariner-io/subctl/commits/release-0.18
* https://github.com/submariner-io/submariner/commits/release-0.18
* https://github.com/submariner-io/submariner-charts/commits/release-0.18
* https://github.com/submariner-io/submariner-operator/commits/release-0.18