### PR TITLE
Advancing 0.15.5 release to status: released

### DIFF
--- a/releases/v0.15.5.yaml
+++ b/releases/v0.15.5.yaml
@@ -2,7 +2,7 @@
 version: v0.15.5
 name: 0.15.5
 branch: release-0.15
-status: installers
+status: released
 components:
   shipyard: 2b51dcd1982eae5c17cffaea11638fb61b40f800
   admiral: af5192e27e7dabb1f446b12086bc279d644e58ef
@@ -10,3 +10,5 @@ components:
   lighthouse: 17efac8d93fb09088eb09921de7a856b00307bcc
   submariner: 511b86d309311ee1d67f902cce8308eaf905bcd3
   submariner-operator: 4dd55e33d863b3fdf57a9d1903e874429bf5de6e
+  subctl: 5ae9c56c59ad2f05e050e0a69dadafd582df2154
+  submariner-charts: 6a652f0f2d927a2acef758c88e7b262a58118352


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.15
* https://github.com/submariner-io/cloud-prepare/commits/release-0.15
* https://github.com/submariner-io/lighthouse/commits/release-0.15
* https://github.com/submariner-io/shipyard/commits/release-0.15
* https://github.com/submariner-io/subctl/commits/release-0.15
* https://github.com/submariner-io/submariner/commits/release-0.15
* https://github.com/submariner-io/submariner-charts/commits/release-0.15
* https://github.com/submariner-io/submariner-operator/commits/release-0.15