### PR TITLE
Advancing 0.19.0-rc0 release to status: shipyard

### DIFF
--- a/releases/v0.19.0-rc0.yaml
+++ b/releases/v0.19.0-rc0.yaml
@@ -2,4 +2,6 @@
 version: v0.19.0-rc0
 name: 0.19.0-rc0
 branch: release-0.19
-status: branch
+status: shipyard
+components:
+  shipyard: 35f3468294128ce32bec0d775ff3131127dd9076


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/shipyard/commits/release-0.19