### PR TITLE
Advancing 0.18.1 release to status: installers

### DIFF
--- a/releases/v0.18.1.yaml
+++ b/releases/v0.18.1.yaml
@@ -2,10 +2,11 @@
 version: v0.18.1
 name: 0.18.1
 branch: release-0.18
-status: projects
+status: installers
 components:
   shipyard: 696df806fe364edc30c0ecc9fed2228d74162cd4
   admiral: 5a7413a16ce2c6f81b6219c27de4c5cdddc40392
   cloud-prepare: f26faa2935a1d457c090f5c573934e6d466be294
   lighthouse: 1b16bf38e859b8f0fd6c9f48c376bac8a5258408
   submariner: b035158395ce1ec17c70bcbe15e9eea8fb3cc12f
+  submariner-operator: 94d002c2793f039c7ef0630ccf3aecafa04209c0


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.18
* https://github.com/submariner-io/cloud-prepare/commits/release-0.18
* https://github.com/submariner-io/lighthouse/commits/release-0.18
* https://github.com/submariner-io/shipyard/commits/release-0.18
* https://github.com/submariner-io/submariner/commits/release-0.18
* https://github.com/submariner-io/submariner-operator/commits/release-0.18