### PR TITLE
Advancing 0.18.2 release to status: installers

### DIFF
--- a/releases/v0.18.2.yaml
+++ b/releases/v0.18.2.yaml
@@ -2,10 +2,11 @@
 version: v0.18.2
 name: 0.18.2
 branch: release-0.18
-status: projects
+status: installers
 components:
   shipyard: 8a76f3b57859a1233bd9becec215b13836d564b8
   admiral: ff93fbefc6291ef50756ea25268e10b70b7324d9
   cloud-prepare: 41faf0c879f9519f2cdfe7d757edb7f323591324
   lighthouse: 5809ae41628f79765b2760b902d06d883389f4ed
   submariner: 6621b503d8a4ea24502f465d38694810217dffd7
+  submariner-operator: b1a5ce96efec74082e148d8934c9461671fc6643


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.18
* https://github.com/submariner-io/cloud-prepare/commits/release-0.18
* https://github.com/submariner-io/lighthouse/commits/release-0.18
* https://github.com/submariner-io/shipyard/commits/release-0.18
* https://github.com/submariner-io/submariner/commits/release-0.18
* https://github.com/submariner-io/submariner-operator/commits/release-0.18