### PR TITLE
Advancing 0.17.4 release to status: released

### DIFF
--- a/releases/v0.17.4.yaml
+++ b/releases/v0.17.4.yaml
@@ -2,7 +2,7 @@
 version: v0.17.4
 name: 0.17.4
 branch: release-0.17
-status: installers
+status: released
 components:
   shipyard: ea99037d25e963993a7eaae756128751d7b0dd59
   admiral: a977b445af2132a098053ea736b29c625c73c6dd
@@ -10,3 +10,5 @@ components:
   lighthouse: ce82399bfdf925511e66e9e65856751af8a20404
   submariner: 7f6e81c09ab3bc1b98b6ac4fca9212d84ed894c9
   submariner-operator: e477b3850c6e760986d8d9ba8c182c6a48577286
+  subctl: 45512ccc776f76765a5bd07deacd3f06dba47e7a
+  submariner-charts: 0229f4ddd47d83ce765ace63c56bfa30db65e1be


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.17
* https://github.com/submariner-io/cloud-prepare/commits/release-0.17
* https://github.com/submariner-io/lighthouse/commits/release-0.17
* https://github.com/submariner-io/shipyard/commits/release-0.17
* https://github.com/submariner-io/subctl/commits/release-0.17
* https://github.com/submariner-io/submariner/commits/release-0.17
* https://github.com/submariner-io/submariner-charts/commits/release-0.17
* https://github.com/submariner-io/submariner-operator/commits/release-0.17