### PR TITLE
Advancing 0.18.3 release to status: installers

### DIFF
--- a/releases/v0.18.3.yaml
+++ b/releases/v0.18.3.yaml
@@ -1,0 +1,7 @@
+---
+version: v0.18.3
+name: 0.18.3
+branch: release-0.18
+status: shipyard
+components:
+  shipyard: a10987b0b7cf3984f61c019fc58a97d5736de1a3

--- a/releases/v0.18.3.yaml
+++ b/releases/v0.18.3.yaml
@@ -2,6 +2,7 @@
 version: v0.18.3
 name: 0.18.3
 branch: release-0.18
-status: shipyard
+status: admiral
 components:
   shipyard: a10987b0b7cf3984f61c019fc58a97d5736de1a3
+  admiral: c9658231e6b7658a4c27ea4b6f01cc6922698d5e

--- a/releases/v0.18.3.yaml
+++ b/releases/v0.18.3.yaml
@@ -2,7 +2,10 @@
 version: v0.18.3
 name: 0.18.3
 branch: release-0.18
-status: admiral
+status: projects
 components:
   shipyard: a10987b0b7cf3984f61c019fc58a97d5736de1a3
   admiral: c9658231e6b7658a4c27ea4b6f01cc6922698d5e
+  cloud-prepare: 4ec016af5ee721649017e7b376a38fe4e2fecab6
+  lighthouse: 4e7ba72d1488aac90c62723bb55c4637149408b0
+  submariner: 7b209f054f9a81aa1cc3a03dc476b0d5bb000c8c

--- a/releases/v0.18.3.yaml
+++ b/releases/v0.18.3.yaml
@@ -2,7 +2,7 @@
 version: v0.18.3
 name: 0.18.3
 branch: release-0.18
-status: installers
+status: released
 components:
   shipyard: a10987b0b7cf3984f61c019fc58a97d5736de1a3
   admiral: c9658231e6b7658a4c27ea4b6f01cc6922698d5e
@@ -10,3 +10,5 @@ components:
   lighthouse: 4e7ba72d1488aac90c62723bb55c4637149408b0
   submariner: 7b209f054f9a81aa1cc3a03dc476b0d5bb000c8c
   submariner-operator: c59c0000027604ec4e0f4f5fcbaf4af087e642b3
+  subctl: 0b2a3c0f56af0818eff390cc758fae7da0f3bc27
+  submariner-charts: 65e7290596b4a1cd1ee207504b017141c183fdf7

--- a/releases/v0.18.3.yaml
+++ b/releases/v0.18.3.yaml
@@ -2,10 +2,11 @@
 version: v0.18.3
 name: 0.18.3
 branch: release-0.18
-status: projects
+status: installers
 components:
   shipyard: a10987b0b7cf3984f61c019fc58a97d5736de1a3
   admiral: c9658231e6b7658a4c27ea4b6f01cc6922698d5e
   cloud-prepare: 4ec016af5ee721649017e7b376a38fe4e2fecab6
   lighthouse: 4e7ba72d1488aac90c62723bb55c4637149408b0
   submariner: 7b209f054f9a81aa1cc3a03dc476b0d5bb000c8c
+  submariner-operator: c59c0000027604ec4e0f4f5fcbaf4af087e642b3


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.18
* https://github.com/submariner-io/cloud-prepare/commits/release-0.18
* https://github.com/submariner-io/lighthouse/commits/release-0.18
* https://github.com/submariner-io/shipyard/commits/release-0.18
* https://github.com/submariner-io/submariner/commits/release-0.18
* https://github.com/submariner-io/submariner-operator/commits/release-0.18