### PR TITLE
Advancing 0.18.4 release to status: released

### DIFF
--- a/releases/v0.18.4.yaml
+++ b/releases/v0.18.4.yaml
@@ -2,7 +2,7 @@
 version: v0.18.4
 name: 0.18.4
 branch: release-0.18
-status: installers
+status: released
 components:
   shipyard: db40d69b8df686b6e19bcd237d508b9e3b61e624
   admiral: ccc924df860c2b713531b63751d3e319c51dc92d
@@ -10,3 +10,5 @@ components:
   lighthouse: 8a61a81d6edf54a3041cb3aa51480c461ded6d67
   submariner: c8dd935e2c756e8f7a6a525efd0bfdc1bb36daec
   submariner-operator: 6775ca5a802777e0e3f9fc372e3bba1951c64149
+  subctl: 7ea55701a134216cd8087f9cbb1ed14fc9129d55
+  submariner-charts: 025c7a670aee0b5f779d95cb998422b54bca92a4


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.18
* https://github.com/submariner-io/cloud-prepare/commits/release-0.18
* https://github.com/submariner-io/lighthouse/commits/release-0.18
* https://github.com/submariner-io/shipyard/commits/release-0.18
* https://github.com/submariner-io/subctl/commits/release-0.18
* https://github.com/submariner-io/submariner/commits/release-0.18
* https://github.com/submariner-io/submariner-charts/commits/release-0.18
* https://github.com/submariner-io/submariner-operator/commits/release-0.18