### PR TITLE
Advancing 0.19.2 release to status: released

### DIFF
--- a/releases/v0.19.2.yaml
+++ b/releases/v0.19.2.yaml
@@ -2,7 +2,7 @@
 version: v0.19.2
 name: 0.19.2
 branch: release-0.19
-status: installers
+status: released
 components:
   shipyard: 176060bf5a0f4dc2880d3a27bce2dc865e9968fc
   admiral: ac1153469a17da8446dd44677c0656979bcc31ca
@@ -10,3 +10,5 @@ components:
   lighthouse: c138ebf9dfe95330fe28f609f6b53e767afc08ec
   submariner: 0b83248e63f19351560c8d10b50c365f08c2db23
   submariner-operator: 87a5522dbead11b7b3c72fbc34a58315030457e9
+  subctl: 42c5d1e655d69a38635202f8b2793c0c7954979c
+  submariner-charts: 3ba8bc3ef00b63048784bef7018bb49f5c74d30d


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.19
* https://github.com/submariner-io/cloud-prepare/commits/release-0.19
* https://github.com/submariner-io/lighthouse/commits/release-0.19
* https://github.com/submariner-io/shipyard/commits/release-0.19
* https://github.com/submariner-io/subctl/commits/release-0.19
* https://github.com/submariner-io/submariner/commits/release-0.19
* https://github.com/submariner-io/submariner-charts/commits/release-0.19
* https://github.com/submariner-io/submariner-operator/commits/release-0.19