### PR TITLE
Advancing 0.18.5 release to status: released

### DIFF
--- a/releases/v0.18.5.yaml
+++ b/releases/v0.18.5.yaml
@@ -2,7 +2,7 @@
 version: v0.18.5
 name: 0.18.5
 branch: release-0.18
-status: installers
+status: released
 components:
   shipyard: 637b882df20d86cd310f18e0e9cad45ecf10dcec
   admiral: d1a231cff6d7b3aae01358174e5db66b52ac7adf
@@ -10,3 +10,5 @@ components:
   lighthouse: eba6d57686e87e34c1517b8d61d415b19b3674f3
   submariner: f799afb0b3ffc587c61cb3c61c287b2116ced7d5
   submariner-operator: cd3edfa1679be1e53dfcd8e45750e594a8067f9a
+  subctl: 4b9f98f0f3996f22b003e2dfdb8059b93789e290
+  submariner-charts: 49e2b694b62b89e7a9dc0de9caddabd723661438


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.18
* https://github.com/submariner-io/cloud-prepare/commits/release-0.18
* https://github.com/submariner-io/lighthouse/commits/release-0.18
* https://github.com/submariner-io/shipyard/commits/release-0.18
* https://github.com/submariner-io/subctl/commits/release-0.18
* https://github.com/submariner-io/submariner/commits/release-0.18
* https://github.com/submariner-io/submariner-charts/commits/release-0.18
* https://github.com/submariner-io/submariner-operator/commits/release-0.18