### PR TITLE
Advancing 0.20.1 release to status: released

### DIFF
--- a/releases/v0.20.1.yaml
+++ b/releases/v0.20.1.yaml
@@ -2,7 +2,7 @@
 version: v0.20.1
 name: 0.20.1
 branch: release-0.20
-status: installers
+status: released
 components:
   shipyard: 71ea18a53850490c087c354a07cbbd853976ccd2
   admiral: 2afbdb6ef160d205b98eb5bb289a4c9197fd2076
@@ -10,3 +10,5 @@ components:
   lighthouse: 20be141120717730a92230d23da07544830c1487
   submariner: a1fabe7102a758f799a6b7f77ae64dd2ff0e635e
   submariner-operator: ee33bdf5cc655b22267fbb9b7015dab8b4a68609
+  subctl: 8e6690d096571e48b2407f1ee8efd222c21268e6
+  submariner-charts: 76eb902bbe745b3dcb98301a523b95ad5545aaa5


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.20
* https://github.com/submariner-io/cloud-prepare/commits/release-0.20
* https://github.com/submariner-io/lighthouse/commits/release-0.20
* https://github.com/submariner-io/shipyard/commits/release-0.20
* https://github.com/submariner-io/subctl/commits/release-0.20
* https://github.com/submariner-io/submariner/commits/release-0.20
* https://github.com/submariner-io/submariner-charts/commits/release-0.20
* https://github.com/submariner-io/submariner-operator/commits/release-0.20