### PR TITLE
Advancing 0.21.0-rc0 release to status: released

### DIFF
--- a/releases/v0.21.0-rc0.yaml
+++ b/releases/v0.21.0-rc0.yaml
@@ -2,7 +2,7 @@
 version: v0.21.0-rc0
 name: 0.21.0-rc0
 branch: release-0.21
-status: installers
+status: released
 components:
   shipyard: f8d812e114a669154651a570edcc68dcc44bc18d
   admiral: 1cd6f8b9796bff6c57ff9f86314c40f1e2ceed9d
@@ -10,3 +10,5 @@ components:
   lighthouse: f69bcebac2ed4245a687c33f4a59975fc0865587
   submariner: 2f0111a4d64336f771e2227be9601057bb32119b
   submariner-operator: 66f589183aff98a8602b6b7c658b9716dff2dc6c
+  subctl: 1b258ef0213732b8ab8b6beaec084107b581cc6b
+  submariner-charts: cc4b8ea89f3c179143a74792dc5a6183ed803514


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.21
* https://github.com/submariner-io/cloud-prepare/commits/release-0.21
* https://github.com/submariner-io/lighthouse/commits/release-0.21
* https://github.com/submariner-io/shipyard/commits/release-0.21
* https://github.com/submariner-io/subctl/commits/release-0.21
* https://github.com/submariner-io/submariner/commits/release-0.21
* https://github.com/submariner-io/submariner-charts/commits/release-0.21
* https://github.com/submariner-io/submariner-operator/commits/release-0.21