### PR TITLE
Advancing 0.21.1 release to status: projects

### DIFF
--- a/releases/v0.21.1.yaml
+++ b/releases/v0.21.1.yaml
@@ -7,5 +7,5 @@ components:
   shipyard: 062b054eae878748ae3ed2a7163e28ca6bb469c7
   admiral: 0d9043616736f94a5b2b357920c599a804eb4023
   cloud-prepare: d2f96e317363ccf84cbf3e3c277926bd63ac0e49
-  lighthouse: 8fffcba318d62493208cc97dcdaded099334f4ba
+  lighthouse: 1c2f0c0c7355d2feb8cd29ff248e7e6634d7cab2
   submariner: 9d8af83cdb42daef749f28b13d0f6c58347d2270

--- a/releases/v0.21.1.yaml
+++ b/releases/v0.21.1.yaml
@@ -2,7 +2,10 @@
 version: v0.21.1
 name: 0.21.1
 branch: release-0.21
-status: admiral
+status: projects
 components:
   shipyard: 062b054eae878748ae3ed2a7163e28ca6bb469c7
   admiral: 0d9043616736f94a5b2b357920c599a804eb4023
+  cloud-prepare: 24784494e26b42cf5e3a43769b869b8aa578761c
+  lighthouse: 8fffcba318d62493208cc97dcdaded099334f4ba
+  submariner: 9d8af83cdb42daef749f28b13d0f6c58347d2270

--- a/releases/v0.21.1.yaml
+++ b/releases/v0.21.1.yaml
@@ -6,6 +6,6 @@ status: projects
 components:
   shipyard: 062b054eae878748ae3ed2a7163e28ca6bb469c7
   admiral: 0d9043616736f94a5b2b357920c599a804eb4023
-  cloud-prepare: 24784494e26b42cf5e3a43769b869b8aa578761c
+  cloud-prepare: d2f96e317363ccf84cbf3e3c277926bd63ac0e49
   lighthouse: 8fffcba318d62493208cc97dcdaded099334f4ba
   submariner: 9d8af83cdb42daef749f28b13d0f6c58347d2270

--- a/releases/v0.21.1.yaml
+++ b/releases/v0.21.1.yaml
@@ -8,4 +8,4 @@ components:
   admiral: 0d9043616736f94a5b2b357920c599a804eb4023
   cloud-prepare: d2f96e317363ccf84cbf3e3c277926bd63ac0e49
   lighthouse: 1c2f0c0c7355d2feb8cd29ff248e7e6634d7cab2
-  submariner: 9d8af83cdb42daef749f28b13d0f6c58347d2270
+  submariner: 65f29fb8f92eb25f07901d2aaa9e7904c78da0f2


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.21
* https://github.com/submariner-io/cloud-prepare/commits/release-0.21
* https://github.com/submariner-io/lighthouse/commits/release-0.21
* https://github.com/submariner-io/shipyard/commits/release-0.21
* https://github.com/submariner-io/submariner/commits/release-0.21
Depends on https://github.com/submariner-io/cloud-prepare/pull/1217
Depends on https://github.com/submariner-io/lighthouse/pull/1946
Depends on https://github.com/submariner-io/submariner/pull/3696