### PR TITLE
Advancing 0.21.2 release to status: installers

### DIFF
--- a/releases/v0.21.2.yaml
+++ b/releases/v0.21.2.yaml
@@ -2,10 +2,11 @@
 version: v0.21.2
 name: 0.21.2
 branch: release-0.21
-status: projects
+status: installers
 components:
   shipyard: 9048b8a00aa93cb901b4b0b2e75029c90950b50f
   admiral: 2eb92fb8816d5261b1a135754800adbe5831ecaf
   cloud-prepare: bc92f5fbf27cc4c243190ea2d0cc396c8b90940b
   lighthouse: 1bfe1988e5ce147f325e70db587fc4244149eb42
   submariner: 556a38149341686bf68305e49c58d30410c7b190
+  submariner-operator: d1d6a7e2d57ca07d542f15093ca250bf27c9afe4


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.21
* https://github.com/submariner-io/cloud-prepare/commits/release-0.21
* https://github.com/submariner-io/lighthouse/commits/release-0.21
* https://github.com/submariner-io/shipyard/commits/release-0.21
* https://github.com/submariner-io/submariner/commits/release-0.21
* https://github.com/submariner-io/submariner-operator/commits/release-0.21