### PR TITLE
Advancing 0.21.2 release to status: released

### DIFF
--- a/releases/v0.21.2.yaml
+++ b/releases/v0.21.2.yaml
@@ -2,7 +2,7 @@
 version: v0.21.2
 name: 0.21.2
 branch: release-0.21
-status: installers
+status: released
 components:
   shipyard: 9048b8a00aa93cb901b4b0b2e75029c90950b50f
   admiral: 2eb92fb8816d5261b1a135754800adbe5831ecaf
@@ -10,3 +10,5 @@ components:
   lighthouse: 1bfe1988e5ce147f325e70db587fc4244149eb42
   submariner: 556a38149341686bf68305e49c58d30410c7b190
   submariner-operator: d1d6a7e2d57ca07d542f15093ca250bf27c9afe4
+  subctl: 9a53c1343360b4221705dff6c40b62f721053ce7
+  submariner-charts: 1d5a361cab488f8e56048cb3b0bcc41500635c29


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.21
* https://github.com/submariner-io/cloud-prepare/commits/release-0.21
* https://github.com/submariner-io/lighthouse/commits/release-0.21
* https://github.com/submariner-io/shipyard/commits/release-0.21
* https://github.com/submariner-io/subctl/commits/release-0.21
* https://github.com/submariner-io/submariner/commits/release-0.21
* https://github.com/submariner-io/submariner-charts/commits/release-0.21
* https://github.com/submariner-io/submariner-operator/commits/release-0.21