### PR TITLE
Advancing 0.22.0-rc1 release to status: installers

### DIFF
--- a/releases/v0.22.0-rc1.yaml
+++ b/releases/v0.22.0-rc1.yaml
@@ -2,10 +2,11 @@
 version: v0.22.0-rc1
 name: 0.22.0-rc1
 branch: release-0.22
-status: projects
+status: installers
 components:
   shipyard: c709a93cc7978dc0fba62f8240a3476306ab6b1c
   admiral: a3ecedbb49cc8a7267b8fbacf2317d5f3375eb1e
   cloud-prepare: 227d6f130e7772be1eed6c247179ce5bd6ea6cad
   lighthouse: 34b6a0a24b6924d4230f40f5c7c922a2b0a04695
   submariner: 500d2afef0e5e5e8448fd8a5a55b6457e911857f
+  submariner-operator: dcc2a3e003cb1af0db7dee23b2346e1f7f31e846


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.22
* https://github.com/submariner-io/cloud-prepare/commits/release-0.22
* https://github.com/submariner-io/lighthouse/commits/release-0.22
* https://github.com/submariner-io/shipyard/commits/release-0.22
* https://github.com/submariner-io/submariner/commits/release-0.22
* https://github.com/submariner-io/submariner-operator/commits/release-0.22