### PR TITLE
Advancing 0.23.1 release to status: released

### DIFF
--- a/releases/v0.23.1.yaml
+++ b/releases/v0.23.1.yaml
@@ -2,7 +2,7 @@
 version: v0.23.1
 name: 0.23.1
 branch: release-0.23
-status: installers
+status: released
 components:
   shipyard: b53b885ef1bc0d38b6cdcd21b7d8048c2dc272de
   admiral: d98b0bc08d523cfe1786aa285a1bd866f608cecf
@@ -10,3 +10,5 @@ components:
   lighthouse: 1331cca399db7afb5903b5e5dfcfd0ca363515a6
   submariner: 2ec8503c6e94ace8cd4a234413528b2d8681d988
   submariner-operator: 59e76678b9bc8b9e7befcb4a4f09c0720f4e5a61
+  subctl: ec8895672c47eeb2ae8857a0201a378ba7484cc2
+  submariner-charts: 756f12eada75c6bb065930fc912c70f2bd737122


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.23
* https://github.com/submariner-io/cloud-prepare/commits/release-0.23
* https://github.com/submariner-io/lighthouse/commits/release-0.23
* https://github.com/submariner-io/shipyard/commits/release-0.23
* https://github.com/submariner-io/subctl/commits/release-0.23
* https://github.com/submariner-io/submariner/commits/release-0.23
* https://github.com/submariner-io/submariner-charts/commits/release-0.23
* https://github.com/submariner-io/submariner-operator/commits/release-0.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 0.23.1 has been released with finalized component packages ready for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->