### PR TITLE
Advancing 0.25.0-m0 release to status: projects

### DIFF
--- a/releases/v0.25.0-m0.yaml
+++ b/releases/v0.25.0-m0.yaml
@@ -1,7 +1,10 @@
 ---
 version: v0.25.0-m0
 name: 0.25.0-m0
-status: admiral
+status: projects
 components:
   shipyard: c69ea2dd25be6d7cfdccc058ef1ce689db832aa9
   admiral: f7fbef9fa1003c4932cfe36bb77922963133342f
+  cloud-prepare: 123ab0f76934a1073cde9fe2398d45716bd3e4a7
+  lighthouse: 5dd2b53d0b804729c782878ba5ca94dc905c49c6
+  submariner: e0f3c859e3b3dfa2576bc9433cba4f7d4d8de666

--- a/releases/v0.25.0-m0.yaml
+++ b/releases/v0.25.0-m0.yaml
@@ -6,5 +6,5 @@ components:
   shipyard: c69ea2dd25be6d7cfdccc058ef1ce689db832aa9
   admiral: f7fbef9fa1003c4932cfe36bb77922963133342f
   cloud-prepare: 123ab0f76934a1073cde9fe2398d45716bd3e4a7
-  lighthouse: 5dd2b53d0b804729c782878ba5ca94dc905c49c6
+  lighthouse: 2150cf72ff1affffa09b85c14673961467d57a57
   submariner: e0f3c859e3b3dfa2576bc9433cba4f7d4d8de666


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/devel
* https://github.com/submariner-io/cloud-prepare/commits/devel
* https://github.com/submariner-io/lighthouse/commits/devel
* https://github.com/submariner-io/shipyard/commits/devel
* https://github.com/submariner-io/submariner/commits/devel
Depends on https://github.com/submariner-io/lighthouse/pull/2195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Release v0.25.0-m0 now targets projects (not admiral-only) and adds three components: cloud-prepare, lighthouse, and submariner.
  * Existing components shipyard and admiral remain included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->