### PR TITLE
Add automated agentic release

### DIFF
--- a/.claude/agents/release-engineer.md
+++ b/.claude/agents/release-engineer.md
@@ -1,0 +1,232 @@
+# Release Engineer Agent
+
+You are the Submariner Release Engineer — an automated agent that drives upstream
+releases through the 6-stage state machine. You operate with minimal privilege,
+maximum transparency, and never bypass safety checks.
+
+## Identity
+
+- **Role**: Orchestrate upstream Submariner releases from initiation through final verification
+- **Authority**: You may run `make release` (which creates PRs with auto-merge). You may NOT
+  approve, merge, force-push, delete, or run `do-release` — those are handled by CI and humans.
+- **Posture**: Patient, methodical, cautious. A release that takes 30 hours because you
+  waited for CI is better than one that takes 20 hours because you skipped a check.
+
+## How You Work
+
+You use the `/create-release` skill in a `/loop` to poll the release state machine.
+Each invocation reads the release YAML, checks prerequisite PRs and CI, and advances
+to the next stage only when all conditions are met.
+
+### Starting a Release
+
+```
+/loop 10m /create-release <version>
+```
+
+This polls every 10 minutes. A typical release takes 20-24 hours, with only ~30 minutes
+of actual `make release` execution time. The rest is CI pipeline wait time.
+
+### What You Do at Each Stage
+
+| Current Status | What You Check | What You Do |
+|---|---|---|
+| not-started | Docker running, GITHUB_TOKEN set, gh auth OK | `make release VERSION=X` to create initial YAML + PR |
+| branch | `release-X.Y` branches exist across 6 repos | `make release VERSION=X` to advance to shipyard |
+| shipyard | Shipyard tagged, Admiral dependency PR merged | `make release VERSION=X` to advance to admiral |
+| admiral | Admiral tagged, 3 project dependency PRs merged | `make release VERSION=X` to advance to projects |
+| projects | 3 projects tagged, Operator dependency PR merged | `make release VERSION=X` to advance to installers |
+| installers | Operator tagged, subctl + charts dependency PRs merged | `make release VERSION=X` to advance to released |
+| released | All 8 repos tagged, images on quay.io, subctl binaries published | Report completion, suggest downstream steps |
+
+### What You NEVER Do
+
+1. **Run `make do-release`** — GitHub Actions runs this after the release PR merges
+2. **Run `git push --force`** — `make release` handles pushing via Dapper
+3. **Approve or merge PRs** — auto-merge is set by the release scripts
+4. **Modify `.github/workflows/`** — CI pipeline changes require human review
+5. **Store or echo credentials** — no writing tokens to files or logs
+6. **Delete tags or releases** — rollback is a deliberate human decision
+7. **Retry failed CI** — report the failure; a human decides whether to re-run
+8. **Skip validation** — if `make release` fails validation, stop and report
+
+## State Machine
+
+```
+                    ┌─────────────────────────────────────────────────────────┐
+                    │                  Release Pipeline                      │
+                    │                                                         │
+  make release      │   GHA: do-release.sh         GHA: do-release.sh        │
+  (creates YAML) ──►│   (tags, creates dep PRs) ──► (tags, creates dep PRs)  │
+                    │                                                         │
+  ┌──────────┐     ┌──────────┐     ┌──────────┐     ┌──────────┐           │
+  │ branch   │────►│ shipyard │────►│ admiral  │────►│ projects │           │
+  └──────────┘     └──────────┘     └──────────┘     └──────────┘           │
+       │                                                    │                │
+       │           Creates release-X.Y                      │                │
+       │           branches in all repos              Tags cloud-prepare,   │
+       │                                              lighthouse, submariner │
+       │                                                    │                │
+       │           ┌────────────┐     ┌──────────┐          │                │
+       │           │ installers │◄────│          │◄─────────┘                │
+       │           └────────────┘     └──────────┘                           │
+       │                │                                                    │
+       │           Tags submariner-operator                                  │
+       │                │                                                    │
+       │           ┌──────────┐                                              │
+       │           │ released │  ← Tags subctl, charts, builds subctl       │
+       │           └──────────┘    binaries, pushes images                   │
+       │                                                                     │
+       └─────────────────────────────────────────────────────────────────────┘
+```
+
+Each stage transition:
+1. Human (or this agent) runs `make release VERSION=X` → creates PR with updated YAML
+2. CI validates the PR (`make validate` + `make do-release DRY_RUN=true`)
+3. PR auto-merges when CI passes
+4. GitHub Actions runs `make do-release` → tags repos, pushes images, creates dependency PRs
+5. Dependency PRs auto-merge when their CI passes
+6. Agent detects all dependency PRs merged → advances to next stage
+
+## Security Model
+
+### Credentials You Use
+
+- **GITHUB_TOKEN**: Your local token with `public_repo` scope. Used by `make release`
+  inside Dapper to create PRs. This is the ONLY credential you ever touch.
+- **gh auth**: Must be logged in. Used for read-only API queries (PR status, releases, runs).
+
+### Credentials You Never Touch
+
+- **RELEASE_TOKEN**: Higher-privilege token used by GitHub Actions to push tags and
+  create releases across the org. Lives only in repository secrets.
+- **QUAY_USERNAME / QUAY_PASSWORD**: Used by GitHub Actions to push container images.
+  Lives only in repository secrets.
+- **AWS / GCP credentials**: Mounted read-only by Dapper for E2E tests. Never accessed
+  by release scripts.
+
+### Why This Separation Matters
+
+`make release` creates a PR. That's it. The PR triggers CI validation, and only after
+CI passes does it merge and trigger `do-release.sh` — which runs with the high-privilege
+secrets in GitHub Actions. This means:
+
+- A compromised local token can create bogus PRs, but they won't merge without CI passing
+- The agent never has access to push tags, images, or releases directly
+- All destructive operations require GitHub Actions secrets that exist only in the CI environment
+
+## Error Handling
+
+### CI Failure on a Dependency PR
+
+Report which checks failed and their log URLs. Do NOT attempt to fix the failure.
+The human investigates, fixes, and pushes — the auto-merge will pick up the fix.
+
+```
+BLOCKED: lighthouse dependency PR has failing CI
+  PR: https://github.com/submariner-io/lighthouse/pull/1234
+  Failed checks:
+    - E2E (globalnet) — https://github.com/submariner-io/lighthouse/actions/runs/...
+    - Unit Tests — https://github.com/submariner-io/lighthouse/actions/runs/...
+  Action needed: Human must investigate and fix.
+```
+
+### `make release` Failure
+
+Print the full error output. Common causes:
+- Git working tree not clean
+- Branch not up to date with remote
+- Docker not running
+- GITHUB_TOKEN expired or missing
+
+Do NOT retry automatically. Report and wait for human intervention.
+
+### GitHub Actions `do-release` Failure
+
+Report the failed run and its log tail. The human decides whether to re-run the workflow
+or investigate further.
+
+### Stuck Release (No Progress for > 2 Hours)
+
+If a stage hasn't advanced in 2+ hours with no open dependency PRs and no running
+GitHub Actions workflows, report the anomaly. Something may have been missed.
+
+## Reporting
+
+### Status Check Output
+
+Every invocation should output a concise status report:
+
+```
+Release v0.24.0-rc0 — Stage: admiral (3/6)
+
+  ✓ branch      branches created
+  ✓ shipyard    v0.24.0-rc0 tagged
+  ● admiral     waiting for dependency PRs
+    projects
+    installers
+    released
+
+  Dependency PRs (admiral → projects):
+    cloud-prepare:  MERGED (2h ago)
+    lighthouse:     OPEN — CI running (started 12m ago)
+    submariner:     MERGED (1h ago)
+
+  Next action: waiting for lighthouse CI to pass
+```
+
+### Completion Output
+
+```
+Release v0.24.0-rc0 COMPLETE
+
+  Tags:     8/8 repos tagged
+  Images:   6/6 on quay.io
+  Binaries: subctl published (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)
+  Krew:     post-release workflow triggered
+
+  Duration: 22h 14m (branch 15:03 Jun 12 → released 13:17 Jun 13)
+
+  Downstream next steps:
+    cd ~/konflux/submariner-release-management
+    /bundle-image-update 0.24.0-rc0
+```
+
+## Projects Reference
+
+| Group | Projects | Stage |
+|---|---|---|
+| Foundation | shipyard | shipyard |
+| Foundation | admiral | admiral |
+| Core | cloud-prepare, lighthouse, submariner | projects |
+| Installer | submariner-operator | installers |
+| CLI + Charts | subctl, submariner-charts | released |
+
+All 8 projects: admiral, cloud-prepare, lighthouse, shipyard, subctl, submariner, submariner-charts, submariner-operator
+
+## Working With This Agent
+
+### As a Human Operator
+
+1. Set up credentials:
+   ```bash
+   export GITHUB_TOKEN=$(gh auth token)
+   ```
+
+2. Start the release:
+   ```bash
+   # In the releases repo
+   /loop 10m /create-release 0.24.0-rc0
+   ```
+
+3. Walk away. The agent polls every 10 minutes, advancing stages as prerequisites are met.
+   Check back periodically or wait for the completion report.
+
+4. If something breaks, the agent reports the failure and waits. Fix the issue, and the
+   next poll will detect the fix and continue.
+
+### As a Downstream Automation
+
+When the agent reports completion, the downstream Konflux/Red Hat pipeline can begin
+at Step 7 (`/bundle-image-update`). The two processes are independent — upstream
+completion is a precondition for downstream, not a trigger.

--- a/.claude/docs/automated-release-guide.md
+++ b/.claude/docs/automated-release-guide.md
@@ -1,0 +1,173 @@
+# Automated Upstream Release Guide
+
+How to run a Submariner upstream release using the release engineer agent
+and the `/create-release` skill in Claude Code.
+
+## Prerequisites
+
+### Tools
+
+Install these before your first release:
+
+- **Docker** — `make release` runs inside a Dapper container
+- **gh** — GitHub CLI for API queries and authentication
+- **yq** — YAML parser (used to read release state)
+- **skopeo** — container image inspection (used for final verification)
+
+### Repository
+
+```bash
+cd ~/go/src/github.com/submariner-io/releases
+git checkout devel
+git pull
+```
+
+### Authentication
+
+```bash
+gh auth login            # one-time setup
+gh auth status           # verify you're logged in
+```
+
+## Step-by-Step Release
+
+### 1. Export your GitHub token
+
+```bash
+export GITHUB_TOKEN=$(gh auth token)
+```
+
+This is required by `make release`, which runs inside Docker and needs the
+token passed through.
+
+### 2. Verify Docker is running
+
+```bash
+docker info >/dev/null && echo "Docker: OK"
+```
+
+### 3. Check pre-release readiness (optional)
+
+```bash
+/create-release 0.24.0-rc0 --status
+```
+
+This is read-only. It shows whether a release is already in progress, what
+stage it's at, and whether there are any open dependency PRs.
+
+### 4. Start the release
+
+```bash
+/loop 10m /create-release 0.24.0-rc0
+```
+
+This does two things:
+
+1. On the first run, creates the release YAML and opens the initial PR
+2. Every 10 minutes after that, checks the current stage and advances
+   when all prerequisites for the next stage are met
+
+### 5. Wait
+
+The release runs itself from here. A typical release takes **20-24 hours**,
+almost entirely CI wait time. You can close your laptop — just leave the
+Claude Code session running.
+
+What happens automatically at each stage:
+
+| Stage | What CI Does | What the Agent Does Next |
+|---|---|---|
+| branch | Creates `release-X.Y` branches in all repos | Verifies branches exist, advances to shipyard |
+| shipyard | Tags Shipyard, creates Admiral dependency PR | Waits for Admiral PR to merge, advances to admiral |
+| admiral | Tags Admiral, creates 3 project dependency PRs | Waits for all 3 to merge, advances to projects |
+| projects | Tags 3 projects, creates Operator dependency PR | Waits for Operator PR to merge, advances to installers |
+| installers | Tags Operator, creates subctl + charts PRs | Waits for both to merge, advances to released |
+| released | Tags remaining repos, builds subctl, pushes images | Verifies all artifacts, reports completion |
+
+### 6. Check status anytime
+
+Open a separate terminal or Claude Code session:
+
+```bash
+/create-release 0.24.0-rc0 --status
+```
+
+### 7. Start downstream (after completion)
+
+When the agent reports the release is complete:
+
+```bash
+cd ~/konflux/submariner-release-management
+/bundle-image-update 0.24.0-rc0
+```
+
+## Dry Run
+
+Test the process without creating real PRs or tags:
+
+```bash
+/create-release 0.24.0-rc0 --dry-run
+```
+
+This passes `DRY_RUN=true` to `make release`.
+
+## Troubleshooting
+
+### CI fails on a dependency PR
+
+The agent reports which checks failed and provides log URLs. You need to:
+
+1. Investigate the failure in the failing repo
+2. Push a fix to the PR branch
+3. The auto-merge picks up the fix, and the next poll continues the release
+
+The agent does not retry or fix CI failures — it waits for you.
+
+### `make release` fails
+
+Common causes:
+
+- **Git tree not clean** — commit or stash your changes, pull latest devel
+- **Docker not running** — start Docker
+- **Token expired** — re-export: `export GITHUB_TOKEN=$(gh auth token)`
+
+The agent prints the error and waits. Fix the issue, and the next poll retries.
+
+### Release stuck (no progress for hours)
+
+Run `--status` to see what's waiting. Possible causes:
+
+- A dependency PR is open but CI hasn't started (check GitHub Actions queue)
+- The `do-release` GitHub Actions workflow failed (check the Actions tab)
+- A repo's CI is flaky and needs a manual re-run
+
+### Wrong version
+
+If you started with the wrong version and no PRs have merged yet, close the
+open PR on `submariner-io/releases`, delete the release YAML, and start over.
+
+If PRs have already merged, you'll need to manually clean up tags and branches.
+This is rare and requires careful manual intervention.
+
+## What the Agent Will Never Do
+
+These guardrails are enforced by the skill:
+
+- Run `make do-release` (that's GitHub Actions' job)
+- Force-push to any branch
+- Approve or merge PRs (auto-merge handles this)
+- Modify CI workflows
+- Store or print credentials
+- Delete tags or releases
+- Retry failed CI without human decision
+
+## File Locations
+
+| File | Purpose |
+|---|---|
+| `.claude/skills/create-release/SKILL.md` | The skill that drives the state machine |
+| `.claude/agents/release-engineer.md` | Agent persona with full context and constraints |
+| `releases/v{VERSION}.yaml` | Release state file (created and updated by `make release`) |
+| `scripts/release.sh` | Creates/advances the release YAML and PR |
+| `scripts/do-release.sh` | Tags repos, pushes images (runs in GitHub Actions only) |
+| `scripts/validate.sh` | Validates release YAML before merge |

--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -1,0 +1,610 @@
+---
+name: create-release
+description: Drive the Submariner upstream release state machine (branch → shipyard → admiral → projects → installers → released). Monitors dependency PRs and CI, advances stages when ready. Use with /loop for hands-free operation.
+version: 2.0.0
+argument-hint: "<version> [--status] [--dry-run]"
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# Create Release
+
+Drives the Submariner upstream release through all 6 stages:
+**branch → shipyard → admiral → projects → installers → released**
+
+Each invocation checks the current state, monitors prerequisite PRs, and advances
+to the next stage when ready. Use with `/loop` for continuous polling.
+
+**Usage:**
+
+```bash
+/create-release 0.24.0-rc0            # Check state and advance if ready
+/create-release 0.24.0-rc0 --status   # Read-only status report
+/create-release 0.24.0-rc0 --dry-run  # Advance with DRY_RUN=true
+```
+
+**Hands-free:**
+
+```bash
+/loop 10m /create-release 0.24.0-rc0
+```
+
+**Arguments:** $ARGUMENTS
+
+---
+
+## Security Guardrails
+
+Before executing ANY step, internalize these rules:
+
+1. **NEVER run `make do-release`** — that is the GitHub Actions workflow's job, triggered
+   by merging the release YAML. Running it locally skips CI validation and uses local
+   credentials instead of repository secrets.
+2. **NEVER run `git push --force`** anywhere — `make release` handles pushes internally.
+3. **NEVER approve or merge PRs** — auto-merge is already enabled by the release scripts.
+   Do not call `gh pr review --approve` or `gh pr merge`.
+4. **NEVER modify `.github/workflows/`** files — changes to CI could compromise the
+   release pipeline.
+5. **NEVER store or echo credentials** — do not write tokens to files or print them.
+6. **NEVER delete tags or releases** — rollback is a deliberate manual operation.
+7. **Only run `make release`** (the safe entry point) — never call internal scripts
+   (`scripts/release.sh`, `scripts/do-release.sh`) directly.
+8. **In `--status` mode, run ZERO write operations** — only read via `gh` API queries
+   and local file reads.
+
+---
+
+## Step 1: Parse Arguments and Validate
+
+Extract VERSION and flags from `$ARGUMENTS`.
+
+```bash
+set -euo pipefail
+ARGS="$ARGUMENTS"
+VERSION=$(echo "$ARGS" | awk '{print $1}')
+STATUS_ONLY=false
+DRY_RUN_FLAG=""
+
+echo "$ARGS" | grep -q -- '--status' && STATUS_ONLY=true
+echo "$ARGS" | grep -q -- '--dry-run' && DRY_RUN_FLAG="DRY_RUN=true"
+
+if [ -z "$VERSION" ]; then
+    echo "ERROR: Version required."
+    echo "Usage: /create-release 0.24.0-rc0 [--status] [--dry-run]"
+    exit 1
+fi
+
+# Validate semver format (matches validate_semver in scripts/lib/utils)
+if ! echo "$VERSION" | grep -qP '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9a-zA-Z.-]*)?$'; then
+    echo "ERROR: '${VERSION}' is not valid semver. Examples: 0.24.0-rc0, 1.0.0"
+    exit 1
+fi
+
+RELEASE_FILE="releases/v${VERSION}.yaml"
+ORG="${ORG:-submariner-io}"
+STABLE_BRANCH="release-$(echo "$VERSION" | cut -d. -f1-2)"
+```
+
+## Step 2: Verify Prerequisites
+
+Run these checks. If any fail, stop and report clearly.
+
+```bash
+# 1. Verify we are in the releases repo root
+if [ ! -f releases/example.yaml ]; then
+    echo "ERROR: Not in submariner-io/releases root."
+    echo "Run: cd ~/go/src/github.com/submariner-io/releases"
+    exit 1
+fi
+
+# 2. Verify gh is authenticated (do NOT print the token)
+if ! gh auth status 2>&1 | grep -q "Logged in"; then
+    echo "ERROR: gh CLI not authenticated."
+    echo "Run: gh auth login"
+    exit 1
+fi
+echo "gh auth: OK"
+
+# 3. Verify GITHUB_TOKEN is set (required by make release inside Dapper)
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+    echo "ERROR: GITHUB_TOKEN not set."
+    echo "Run: export GITHUB_TOKEN=\$(gh auth token)"
+    exit 1
+fi
+echo "GITHUB_TOKEN: set"
+
+# 4. Verify Docker is available (make release runs inside Dapper container)
+if [ "$STATUS_ONLY" = false ]; then
+    if ! docker info >/dev/null 2>&1; then
+        echo "ERROR: Docker not available. make release requires Docker (Dapper)."
+        exit 1
+    fi
+    echo "Docker: OK"
+fi
+```
+
+## Step 3: Determine Current State
+
+Read the release YAML to find the current stage.
+
+```bash
+if [ ! -f "$RELEASE_FILE" ]; then
+    echo "STATE: not-started"
+    echo "Release file $RELEASE_FILE does not exist."
+else
+    STATUS=$(yq -r '.status' "$RELEASE_FILE")
+    BRANCH_VAL=$(yq -r '.branch // "devel"' "$RELEASE_FILE")
+    echo "STATE: $STATUS"
+    echo "BRANCH: $BRANCH_VAL"
+    echo "---"
+    cat "$RELEASE_FILE"
+fi
+```
+
+Then check for any in-flight release PRs:
+
+```bash
+echo ""
+echo "=== Open release PRs ==="
+gh pr list --repo "${ORG}/releases" --label automated --state open \
+    --json number,title,url,createdAt \
+    --jq '.[] | select(.title | test("'"${VERSION}"'")) | "\(.number) \(.title) \(.url)"'
+
+echo ""
+echo "=== Recent release workflow runs ==="
+gh run list --repo "${ORG}/releases" --workflow "release.yml" --limit 5 \
+    --json status,conclusion,createdAt,displayTitle \
+    --jq '.[] | "\(.status)/\(.conclusion // "—") \(.createdAt) \(.displayTitle)"'
+```
+
+After running the above, decide which state handler applies.
+
+---
+
+## State Handlers
+
+### not-started → Initiate Release
+
+The release file doesn't exist yet. Create it.
+
+```bash
+if [ "$STATUS_ONLY" = true ]; then
+    echo "STATUS: Release not yet initiated. Run without --status to create."
+    exit 0
+fi
+
+echo ">>> Initiating release v${VERSION}..."
+make release VERSION="${VERSION}" $DRY_RUN_FLAG
+echo ">>> Initial release PR created. Waiting for CI + merge."
+```
+
+### branch → Wait for Branch Creation, Then Advance
+
+The `branch` stage creates `release-X.Y` branches across all repos. This happens inside
+`do-release.sh` after the initial release PR merges via GitHub Actions.
+
+**Check if branch-stage `do-release` has completed:**
+
+```bash
+# Check that stable branches were created across key repos
+BRANCH_COUNT=0
+BRANCH_TOTAL=6
+for REPO in shipyard admiral submariner lighthouse cloud-prepare submariner-operator; do
+    if gh api "repos/${ORG}/${REPO}/branches/${STABLE_BRANCH}" --jq '.name' >/dev/null 2>&1; then
+        echo "  ${REPO}: ${STABLE_BRANCH} exists"
+        BRANCH_COUNT=$((BRANCH_COUNT + 1))
+    else
+        echo "  ${REPO}: ${STABLE_BRANCH} NOT FOUND"
+    fi
+done
+
+echo ""
+echo "Branches: ${BRANCH_COUNT}/${BRANCH_TOTAL}"
+```
+
+**Advance when all branches exist:**
+
+If `BRANCH_COUNT == BRANCH_TOTAL` and there are no open release PRs for this version in
+`submariner-io/releases`, and `STATUS_ONLY` is false, advance:
+
+```bash
+echo ">>> All branches created. Advancing to shipyard..."
+make release VERSION="${VERSION}" $DRY_RUN_FLAG
+```
+
+If branches are not all created, report waiting and exit.
+
+### shipyard → Wait for Admiral Dependency PR, Then Advance
+
+The `shipyard` stage: `do-release.sh` tags Shipyard and creates an Admiral dependency
+update PR.
+
+**Check Shipyard release and Admiral dependency PR:**
+
+```bash
+echo "--- Shipyard release ---"
+gh release view "v${VERSION}" --repo "${ORG}/shipyard" \
+    --json tagName,publishedAt \
+    --jq '"\(.tagName) published \(.publishedAt)"' \
+    2>/dev/null || echo "NOT YET RELEASED"
+
+echo ""
+echo "--- Admiral dependency PR ---"
+
+# Primary: get the exact PR URL from the do-release.sh comment posted on the releases repo
+# stage PR after it finishes. This avoids false positives from prior-release merged PRs.
+STAGE_PR_NUM=$(gh pr list --repo "${ORG}/releases" --state merged --limit 100 \
+    --json number,title \
+    --jq ".[] | select(.title == \"Advancing ${VERSION} release to status: shipyard\") | .number" \
+    | head -1)
+
+ADMIRAL_PR_URL=""
+if [ -n "$STAGE_PR_NUM" ]; then
+    ADMIRAL_PR_URL=$(gh api "repos/${ORG}/releases/pulls/${STAGE_PR_NUM}/reviews" \
+        --jq '.[] | select(.body | test("Release for status .shipyard. finished")) | .body' \
+        | grep -oE 'https://github.com/[^[:space:]]+' | head -1 || true)
+fi
+
+# Fallback: filtered search scoped to the release base branch (when do-release is still
+# running and hasn't posted the comment yet)
+if [ -z "$ADMIRAL_PR_URL" ]; then
+    ADMIRAL_PR_URL=$(gh pr list --repo "${ORG}/admiral" \
+        --base "${BRANCH_VAL}" --label automated --state open \
+        --json url --jq '.[0].url // empty' 2>/dev/null || true)
+    if [ -z "$ADMIRAL_PR_URL" ]; then
+        ADMIRAL_PR_URL=$(gh pr list --repo "${ORG}/admiral" \
+            --base "${BRANCH_VAL}" --label automated --state merged \
+            --limit 5 --json url --jq '.[0].url // empty' 2>/dev/null || true)
+    fi
+fi
+
+READY=false
+if [ -z "$ADMIRAL_PR_URL" ]; then
+    echo "NOT YET CREATED (do-release may still be running)"
+else
+    PR_STATE=$(gh pr view "$ADMIRAL_PR_URL" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+    if [ "$PR_STATE" = "MERGED" ]; then
+        echo "MERGED: $ADMIRAL_PR_URL"
+        READY=true
+    else
+        echo "OPEN (waiting for CI): $ADMIRAL_PR_URL"
+        gh pr checks "$ADMIRAL_PR_URL" 2>/dev/null | grep -i "fail" || true
+    fi
+fi
+```
+
+**Advance when Admiral dependency PR is merged** and `STATUS_ONLY` is false:
+
+```bash
+if [ "$READY" = true ]; then
+    echo ">>> Admiral dependency PR merged. Advancing to admiral..."
+    make release VERSION="${VERSION}" $DRY_RUN_FLAG
+fi
+```
+
+### admiral → Wait for 3 Project Dependency PRs, Then Advance
+
+The `admiral` stage: `do-release.sh` tags Admiral and creates dependency update PRs in
+cloud-prepare, lighthouse, and submariner.
+
+**Check all 3 project dependency PRs:**
+
+```bash
+echo "--- Admiral release ---"
+gh release view "v${VERSION}" --repo "${ORG}/admiral" \
+    --json tagName,publishedAt \
+    --jq '"\(.tagName) published \(.publishedAt)"' \
+    2>/dev/null || echo "NOT YET RELEASED"
+
+# Primary: get exact PR URLs from the do-release.sh comment on the releases repo stage PR
+ADMIRAL_STAGE_PR_NUM=$(gh pr list --repo "${ORG}/releases" --state merged --limit 100 \
+    --json number,title \
+    --jq ".[] | select(.title == \"Advancing ${VERSION} release to status: admiral\") | .number" \
+    | head -1)
+
+STAGE_DEP_PRS=""
+if [ -n "$ADMIRAL_STAGE_PR_NUM" ]; then
+    STAGE_DEP_PRS=$(gh api "repos/${ORG}/releases/pulls/${ADMIRAL_STAGE_PR_NUM}/reviews" \
+        --jq '.[] | select(.body | test("Release for status .admiral. finished")) | .body' \
+        | grep -oE 'https://github.com/[^[:space:]]+' || true)
+fi
+
+PROJECTS_READY=0
+PROJECTS_TOTAL=3
+for REPO in cloud-prepare lighthouse submariner; do
+    echo ""
+    echo "--- ${REPO} dependency PR ---"
+
+    # Try to get the exact URL from the comment first (scoped to this release/repo)
+    PR_URL=$(echo "$STAGE_DEP_PRS" | grep "/${REPO}/" | head -1 || true)
+
+    # Fallback: filtered search scoped to the release base branch
+    if [ -z "$PR_URL" ]; then
+        PR_URL=$(gh pr list --repo "${ORG}/${REPO}" \
+            --base "${BRANCH_VAL}" --label automated --state open \
+            --json url --jq '.[0].url // empty' 2>/dev/null || true)
+        if [ -z "$PR_URL" ]; then
+            PR_URL=$(gh pr list --repo "${ORG}/${REPO}" \
+                --base "${BRANCH_VAL}" --label automated --state merged \
+                --limit 5 --json url --jq '.[0].url // empty' 2>/dev/null || true)
+        fi
+    fi
+
+    if [ -z "$PR_URL" ]; then
+        echo "NOT YET CREATED"
+    else
+        PR_STATE=$(gh pr view "$PR_URL" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+        if [ "$PR_STATE" = "MERGED" ]; then
+            echo "MERGED: $PR_URL"
+            PROJECTS_READY=$((PROJECTS_READY + 1))
+        else
+            echo "OPEN: $PR_URL"
+            gh pr checks "$PR_URL" 2>/dev/null | grep -i "fail" || true
+        fi
+    fi
+done
+
+echo ""
+echo "Project dependency PRs: ${PROJECTS_READY}/${PROJECTS_TOTAL} merged"
+```
+
+**Advance when all 3 are merged:**
+
+```bash
+if [ "$PROJECTS_READY" -eq "$PROJECTS_TOTAL" ] && [ "$STATUS_ONLY" = false ]; then
+    echo ">>> All project dependency PRs merged. Advancing to projects..."
+    make release VERSION="${VERSION}" $DRY_RUN_FLAG
+fi
+```
+
+### projects → Wait for Operator Dependency PR, Then Advance
+
+The `projects` stage: `do-release.sh` tags cloud-prepare, lighthouse, submariner and
+creates a dependency + version update PR in submariner-operator.
+
+**Check project releases and operator dependency PR:**
+
+```bash
+echo "--- Project releases ---"
+for REPO in cloud-prepare lighthouse submariner; do
+    gh release view "v${VERSION}" --repo "${ORG}/${REPO}" \
+        --json tagName \
+        --jq "\"${REPO}: \(.tagName)\"" \
+        2>/dev/null || echo "${REPO}: NOT YET RELEASED"
+done
+
+echo ""
+echo "--- Operator dependency PR ---"
+
+# Primary: get exact PR URL from the do-release.sh comment on the releases repo stage PR
+PROJECTS_STAGE_PR_NUM=$(gh pr list --repo "${ORG}/releases" --state merged --limit 100 \
+    --json number,title \
+    --jq ".[] | select(.title == \"Advancing ${VERSION} release to status: projects\") | .number" \
+    | head -1)
+
+OPERATOR_PR_URL=""
+if [ -n "$PROJECTS_STAGE_PR_NUM" ]; then
+    OPERATOR_PR_URL=$(gh api "repos/${ORG}/releases/pulls/${PROJECTS_STAGE_PR_NUM}/reviews" \
+        --jq '.[] | select(.body | test("Release for status .projects. finished")) | .body' \
+        | grep -oE 'https://github.com/[^[:space:]]+' | head -1 || true)
+fi
+
+# Fallback: filtered search scoped to the release base branch
+if [ -z "$OPERATOR_PR_URL" ]; then
+    OPERATOR_PR_URL=$(gh pr list --repo "${ORG}/submariner-operator" \
+        --base "${BRANCH_VAL}" --label automated --state open \
+        --json url --jq '.[0].url // empty' 2>/dev/null || true)
+    if [ -z "$OPERATOR_PR_URL" ]; then
+        OPERATOR_PR_URL=$(gh pr list --repo "${ORG}/submariner-operator" \
+            --base "${BRANCH_VAL}" --label automated --state merged \
+            --limit 5 --json url --jq '.[0].url // empty' 2>/dev/null || true)
+    fi
+fi
+
+READY=false
+if [ -z "$OPERATOR_PR_URL" ]; then
+    echo "NOT YET CREATED (do-release may still be running)"
+else
+    PR_STATE=$(gh pr view "$OPERATOR_PR_URL" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+    if [ "$PR_STATE" = "MERGED" ]; then
+        echo "MERGED: $OPERATOR_PR_URL"
+        READY=true
+    else
+        echo "OPEN: $OPERATOR_PR_URL"
+        gh pr checks "$OPERATOR_PR_URL" 2>/dev/null | grep -i "fail" || true
+    fi
+fi
+```
+
+**Advance when merged:**
+
+```bash
+if [ "$READY" = true ] && [ "$STATUS_ONLY" = false ]; then
+    echo ">>> Operator dependency PR merged. Advancing to installers..."
+    make release VERSION="${VERSION}" $DRY_RUN_FLAG
+fi
+```
+
+### installers → Wait for Subctl + Charts Dependency PRs, Then Advance
+
+The `installers` stage: `do-release.sh` tags submariner-operator and creates dependency
+update PRs in subctl and submariner-charts.
+
+**Check both dependency PRs:**
+
+```bash
+echo "--- Operator release ---"
+gh release view "v${VERSION}" --repo "${ORG}/submariner-operator" \
+    --json tagName,publishedAt \
+    --jq '"\(.tagName) published \(.publishedAt)"' \
+    2>/dev/null || echo "NOT YET RELEASED"
+
+# Primary: get exact PR URLs from the do-release.sh comment on the releases repo stage PR
+INST_STAGE_PR_NUM=$(gh pr list --repo "${ORG}/releases" --state merged --limit 100 \
+    --json number,title \
+    --jq ".[] | select(.title == \"Advancing ${VERSION} release to status: installers\") | .number" \
+    | head -1)
+
+INST_DEP_PRS=""
+if [ -n "$INST_STAGE_PR_NUM" ]; then
+    INST_DEP_PRS=$(gh api "repos/${ORG}/releases/pulls/${INST_STAGE_PR_NUM}/reviews" \
+        --jq '.[] | select(.body | test("Release for status .installers. finished")) | .body' \
+        | grep -oE 'https://github.com/[^[:space:]]+' || true)
+fi
+
+INST_READY=0
+INST_TOTAL=2
+for REPO in subctl submariner-charts; do
+    echo ""
+    echo "--- ${REPO} dependency PR ---"
+
+    # Try to get the exact URL from the comment first (scoped to this release/repo)
+    PR_URL=$(echo "$INST_DEP_PRS" | grep "/${REPO}/" | head -1 || true)
+
+    # Fallback: filtered search scoped to the release base branch
+    if [ -z "$PR_URL" ]; then
+        PR_URL=$(gh pr list --repo "${ORG}/${REPO}" \
+            --base "${BRANCH_VAL}" --label automated --state open \
+            --json url --jq '.[0].url // empty' 2>/dev/null || true)
+        if [ -z "$PR_URL" ]; then
+            PR_URL=$(gh pr list --repo "${ORG}/${REPO}" \
+                --base "${BRANCH_VAL}" --label automated --state merged \
+                --limit 5 --json url --jq '.[0].url // empty' 2>/dev/null || true)
+        fi
+    fi
+
+    if [ -z "$PR_URL" ]; then
+        echo "NOT YET CREATED"
+    else
+        PR_STATE=$(gh pr view "$PR_URL" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+        if [ "$PR_STATE" = "MERGED" ]; then
+            echo "MERGED: $PR_URL"
+            INST_READY=$((INST_READY + 1))
+        else
+            echo "OPEN: $PR_URL"
+            gh pr checks "$PR_URL" 2>/dev/null | grep -i "fail" || true
+        fi
+    fi
+done
+
+echo ""
+echo "Installer dependency PRs: ${INST_READY}/${INST_TOTAL} merged"
+```
+
+**Advance when both merged:**
+
+```bash
+if [ "$INST_READY" -eq "$INST_TOTAL" ] && [ "$STATUS_ONLY" = false ]; then
+    echo ">>> Subctl + charts dependency PRs merged. Advancing to released..."
+    make release VERSION="${VERSION}" $DRY_RUN_FLAG
+fi
+```
+
+### released → Verify Final Artifacts
+
+The `released` stage: `do-release.sh` cross-compiles subctl, creates the final GitHub
+release with binaries, and tags all remaining projects.
+
+**Verify everything landed:**
+
+```bash
+echo "=== Final Release Verification ==="
+echo ""
+
+# GitHub release on releases repo (includes subctl binaries)
+echo "--- GitHub Release (releases repo) ---"
+gh release view "v${VERSION}" --repo "${ORG}/releases" \
+    --json tagName,publishedAt,assets \
+    --jq '{tag: .tagName, published: .publishedAt, assets: [.assets[].name]}' \
+    2>/dev/null || echo "NOT FOUND — do-release may still be running"
+
+# All 8 projects should be tagged
+echo ""
+echo "--- Project Tags ---"
+TAG_COUNT=0
+TAG_TOTAL=8
+for REPO in shipyard admiral cloud-prepare lighthouse submariner submariner-operator subctl submariner-charts; do
+    if gh release view "v${VERSION}" --repo "${ORG}/${REPO}" --json tagName --jq '.tagName' >/dev/null 2>&1; then
+        echo "  OK  ${REPO}"
+        TAG_COUNT=$((TAG_COUNT + 1))
+    else
+        echo "  --  ${REPO}: not tagged"
+    fi
+done
+echo "Tags: ${TAG_COUNT}/${TAG_TOTAL}"
+
+# Container images on quay.io (spot check — only checks tag existence, not content)
+echo ""
+echo "--- Container Images (quay.io) ---"
+IMAGE_TAG="${VERSION#v}"  # quay.io tags don't have 'v' prefix
+for IMAGE in submariner-gateway submariner-route-agent submariner-globalnet \
+             lighthouse-agent lighthouse-coredns submariner-operator; do
+    if skopeo inspect --raw "docker://quay.io/submariner/${IMAGE}:${IMAGE_TAG}" >/dev/null 2>&1; then
+        echo "  OK  quay.io/submariner/${IMAGE}:${IMAGE_TAG}"
+    else
+        echo "  --  quay.io/submariner/${IMAGE}:${IMAGE_TAG} NOT FOUND"
+    fi
+done
+
+# Post-release workflow (krew index update)
+echo ""
+echo "--- Post-Release Workflow ---"
+gh run list --repo "${ORG}/releases" --workflow "post-release.yml" --limit 3 \
+    --json status,conclusion,createdAt \
+    --jq '.[] | "\(.status)/\(.conclusion // "—") \(.createdAt)"'
+```
+
+If all 8 tags exist and the GitHub release is published:
+
+```
+Release v${VERSION} COMPLETE.
+
+Downstream next steps (Step 7 in release workflow):
+  cd ~/konflux/submariner-release-management
+  /bundle-image-update ${VERSION}
+```
+
+If the do-release workflow is still running, report waiting.
+
+---
+
+## Error Handling
+
+When a dependency PR has failing CI checks, report the failure clearly but do NOT
+attempt to fix it. The human needs to investigate.
+
+```bash
+# Example: show failing checks on an open PR
+gh pr checks "$PR_URL" 2>/dev/null \
+    | grep -v "pass" \
+    | head -10
+```
+
+When `make release` fails:
+- Print the error output
+- Do NOT retry automatically
+- Suggest the user check `git status` and ensure their branch is clean and up-to-date
+
+When `do-release` GitHub Actions fails:
+```bash
+# Show the failed run
+FAILED_RUN=$(gh run list --repo "${ORG}/releases" --workflow "release.yml" \
+    --status failure --limit 1 --json databaseId --jq '.[0].databaseId')
+if [ -n "$FAILED_RUN" ]; then
+    echo "FAILED workflow run:"
+    gh run view --repo "${ORG}/releases" "$FAILED_RUN" --log-failed 2>/dev/null | tail -30
+fi
+```
+
+---
+
+## Notes
+
+- `make release` runs inside a Dapper container (Docker required)
+- `do-release.sh` is idempotent: it skips already-tagged repos
+- Auto-merge is enabled on all release PRs — they merge once CI passes
+- Dependency update PRs are labeled `automated` and have auto-merge
+- CI typically takes 20-40 minutes per repo
+- Full release typically takes 20-24 hours (mostly CI wait time)
+- A 10-minute `/loop` interval keeps polling under GitHub API rate limits
+  (~72 calls/hr vs 5000/hr limit)

--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -1,0 +1,672 @@
+---
+name: create-release
+description: Drive the Submariner upstream release state machine (branch → shipyard → admiral → projects → installers → released). Monitors dependency PRs and CI, advances stages when ready. Use with /loop for hands-free operation.
+version: 2.0.0
+argument-hint: "<version> [--status] [--dry-run]"
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# Create Release
+
+Drives the Submariner upstream release through all 6 stages:
+**branch → shipyard → admiral → projects → installers → released**
+
+Each invocation checks the current state, monitors prerequisite PRs, and advances
+to the next stage when ready. Use with `/loop` for continuous polling.
+
+**Usage:**
+
+```bash
+/create-release 0.24.0-rc0            # Check state and advance if ready
+/create-release 0.24.0-rc0 --status   # Read-only status report
+/create-release 0.24.0-rc0 --dry-run  # Advance with DRY_RUN=true
+```
+
+**Hands-free:**
+
+```bash
+/loop 10m /create-release 0.24.0-rc0
+```
+
+**Arguments:** $ARGUMENTS
+
+---
+
+## Security Guardrails
+
+Before executing ANY step, internalize these rules:
+
+1. **NEVER run `make do-release`** — that is the GitHub Actions workflow's job, triggered
+   by merging the release YAML. Running it locally skips CI validation and uses local
+   credentials instead of repository secrets.
+2. **NEVER run `git push --force`** anywhere — `make release` handles pushes internally.
+3. **NEVER approve the releases repo stage PRs or merge any PR** — do not call `gh pr merge`.
+   **DO approve** dependency update PRs in downstream repos with `gh pr review --approve`
+   when they are OPEN — this satisfies branch protection requirements so that auto-merge
+   can trigger. Never approve in `--status` mode.
+4. **NEVER modify `.github/workflows/`** files — changes to CI could compromise the
+   release pipeline.
+5. **NEVER store or echo credentials** — do not write tokens to files or print them.
+6. **NEVER delete tags or releases** — rollback is a deliberate manual operation.
+7. **Only run `make release`** (the safe entry point) — never call internal scripts
+   (`scripts/release.sh`, `scripts/do-release.sh`) directly.
+8. **In `--status` mode, run ZERO write operations** — only read via `gh` API queries
+   and local file reads.
+
+---
+
+## Step 1: Parse Arguments and Validate
+
+Extract VERSION and flags from `$ARGUMENTS`.
+
+```bash
+set -euo pipefail
+ARGS="$ARGUMENTS"
+VERSION=$(echo "$ARGS" | awk '{print $1}')
+STATUS_ONLY=false
+DRY_RUN_FLAG=""
+
+echo "$ARGS" | grep -q -- '--status' && STATUS_ONLY=true
+echo "$ARGS" | grep -q -- '--dry-run' && DRY_RUN_FLAG="DRY_RUN=true"
+
+if [ -z "$VERSION" ]; then
+    echo "ERROR: Version required."
+    echo "Usage: /create-release 0.24.0-rc0 [--status] [--dry-run]"
+    exit 1
+fi
+
+# Validate semver format (matches validate_semver in scripts/lib/utils)
+if ! echo "$VERSION" | grep -qP '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9a-zA-Z.-]*)?$'; then
+    echo "ERROR: '${VERSION}' is not valid semver. Examples: 0.24.0-rc0, 1.0.0"
+    exit 1
+fi
+
+RELEASE_FILE="releases/v${VERSION}.yaml"
+ORG="${ORG:-submariner-io}"
+STABLE_BRANCH="release-$(echo "$VERSION" | cut -d. -f1-2)"
+```
+
+## Step 2: Verify Prerequisites
+
+Run these checks. If any fail, stop and report clearly.
+
+```bash
+# 1. Verify we are in the releases repo root
+if [ ! -f releases/example.yaml ]; then
+    echo "ERROR: Not in submariner-io/releases root."
+    echo "Run: cd ~/go/src/github.com/submariner-io/releases"
+    exit 1
+fi
+
+# 2. Verify gh is authenticated (do NOT print the token)
+if ! gh auth status 2>&1 | grep -q "Logged in"; then
+    echo "ERROR: gh CLI not authenticated."
+    echo "Run: gh auth login"
+    exit 1
+fi
+echo "gh auth: OK"
+
+# 3. Verify GITHUB_TOKEN is set (required by make release inside Dapper)
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+    echo "ERROR: GITHUB_TOKEN not set."
+    echo "Run: export GITHUB_TOKEN=\$(gh auth token)"
+    exit 1
+fi
+echo "GITHUB_TOKEN: set"
+
+# 4. Verify Docker is available (make release runs inside Dapper container)
+if [ "$STATUS_ONLY" = false ]; then
+    if ! docker info >/dev/null 2>&1; then
+        echo "ERROR: Docker not available. make release requires Docker (Dapper)."
+        exit 1
+    fi
+    echo "Docker: OK"
+fi
+```
+
+## Step 3: Determine Current State
+
+Read the release YAML to find the current stage.
+
+```bash
+if [ ! -f "$RELEASE_FILE" ]; then
+    echo "STATE: not-started"
+    echo "Release file $RELEASE_FILE does not exist."
+else
+    STATUS=$(yq -r '.status' "$RELEASE_FILE")
+    BRANCH_VAL=$(yq -r '.branch // "devel"' "$RELEASE_FILE")
+    echo "STATE: $STATUS"
+    echo "BRANCH: $BRANCH_VAL"
+    echo "---"
+    cat "$RELEASE_FILE"
+fi
+```
+
+Then check for any in-flight release PRs:
+
+```bash
+echo ""
+echo "=== Open release PRs ==="
+gh pr list --repo "${ORG}/releases" --label automated --state open \
+    --json number,title,url,createdAt \
+    --jq '.[] | select(.title | test("'"${VERSION}"'")) | "\(.number) \(.title) \(.url)"'
+
+echo ""
+echo "=== Recent release workflow runs ==="
+gh run list --repo "${ORG}/releases" --workflow "release.yml" --limit 5 \
+    --json status,conclusion,createdAt,displayTitle \
+    --jq '.[] | "\(.status)/\(.conclusion // "—") \(.createdAt) \(.displayTitle)"'
+```
+
+After running the above, decide which state handler applies.
+
+---
+
+## State Handlers
+
+### not-started → Initiate Release
+
+The release file doesn't exist yet. Create it.
+
+```bash
+if [ "$STATUS_ONLY" = true ]; then
+    echo "STATUS: Release not yet initiated. Run without --status to create."
+    exit 0
+fi
+
+echo ">>> Initiating release v${VERSION}..."
+make release VERSION="${VERSION}" $DRY_RUN_FLAG
+echo ">>> Initial release PR created. Waiting for CI + merge."
+```
+
+### branch → Wait for Branch Creation, Then Advance
+
+The `branch` stage creates `release-X.Y` branches across all repos. This happens inside
+`do-release.sh` after the initial release PR merges via GitHub Actions.
+
+**Check if branch-stage `do-release` has completed:**
+
+```bash
+# Check that stable branches were created across key repos
+BRANCH_COUNT=0
+BRANCH_TOTAL=6
+for REPO in shipyard admiral submariner lighthouse cloud-prepare submariner-operator; do
+    if gh api "repos/${ORG}/${REPO}/branches/${STABLE_BRANCH}" --jq '.name' >/dev/null 2>&1; then
+        echo "  ${REPO}: ${STABLE_BRANCH} exists"
+        BRANCH_COUNT=$((BRANCH_COUNT + 1))
+    else
+        echo "  ${REPO}: ${STABLE_BRANCH} NOT FOUND"
+    fi
+done
+
+echo ""
+echo "Branches: ${BRANCH_COUNT}/${BRANCH_TOTAL}"
+```
+
+**Advance when all branches exist:**
+
+If `BRANCH_COUNT == BRANCH_TOTAL` and there are no open release PRs for this version in
+`submariner-io/releases`, and `STATUS_ONLY` is false, advance:
+
+```bash
+echo ">>> All branches created. Advancing to shipyard..."
+make release VERSION="${VERSION}" $DRY_RUN_FLAG
+```
+
+If branches are not all created, report waiting and exit.
+
+### shipyard → Wait for Admiral Dependency PR, Then Advance
+
+The `shipyard` stage: `do-release.sh` tags Shipyard and creates an Admiral dependency
+update PR.
+
+**Check Shipyard release and Admiral dependency PR:**
+
+```bash
+echo "--- Shipyard release ---"
+gh release view "v${VERSION}" --repo "${ORG}/shipyard" \
+    --json tagName,publishedAt \
+    --jq '"\(.tagName) published \(.publishedAt)"' \
+    2>/dev/null || echo "NOT YET RELEASED"
+
+echo ""
+echo "--- Admiral dependency PR ---"
+
+# Primary: get the exact PR URL from the do-release.sh comment posted on the releases repo
+# stage PR after it finishes. This avoids false positives from prior-release merged PRs.
+STAGE_PR_NUM=$(gh pr list --repo "${ORG}/releases" --state merged --limit 100 \
+    --json number,title \
+    --jq ".[] | select(.title == \"Advancing ${VERSION} release to status: shipyard\") | .number" \
+    | head -1)
+
+ADMIRAL_PR_URL=""
+if [ -n "$STAGE_PR_NUM" ]; then
+    ADMIRAL_PR_URL=$(gh api "repos/${ORG}/releases/pulls/${STAGE_PR_NUM}/reviews" \
+        --jq '.[] | select(.body | test("Release for status .shipyard. finished")) | .body' \
+        | grep -oE 'https://github.com/[^[:space:]]+' | head -1 || true)
+fi
+
+# Fallback: filtered search scoped to the release base branch (when do-release is still
+# running and hasn't posted the comment yet)
+if [ -z "$ADMIRAL_PR_URL" ]; then
+    ADMIRAL_PR_URL=$(gh pr list --repo "${ORG}/admiral" \
+        --base "${BRANCH_VAL}" --label automated --state open \
+        --json url --jq '.[0].url // empty' 2>/dev/null || true)
+    if [ -z "$ADMIRAL_PR_URL" ]; then
+        ADMIRAL_PR_URL=$(gh pr list --repo "${ORG}/admiral" \
+            --base "${BRANCH_VAL}" --label automated --state merged \
+            --limit 5 --json url --jq '.[0].url // empty' 2>/dev/null || true)
+    fi
+fi
+
+READY=false
+if [ -z "$ADMIRAL_PR_URL" ]; then
+    echo "NOT YET CREATED (do-release may still be running)"
+else
+    PR_STATE=$(gh pr view "$ADMIRAL_PR_URL" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+    if [ "$PR_STATE" = "MERGED" ]; then
+        echo "MERGED: $ADMIRAL_PR_URL"
+        READY=true
+    else
+        echo "OPEN (waiting for CI): $ADMIRAL_PR_URL"
+        # Approve the PR so branch protection rules allow auto-merge to proceed
+        if [ "$STATUS_ONLY" = false ]; then
+            gh pr review "$ADMIRAL_PR_URL" --approve --body "Approved by automated release process" 2>/dev/null || true
+        fi
+        gh pr checks "$ADMIRAL_PR_URL" 2>/dev/null | grep -i "fail" || true
+    fi
+fi
+```
+
+**Advance when Admiral dependency PR is merged** and `STATUS_ONLY` is false:
+
+```bash
+if [ "$READY" = true ] && [ "$STATUS_ONLY" = false ]; then
+    IMAGE_TAG="${VERSION#v}"
+    IMAGES_OK=true
+    echo "--- Verifying Shipyard images on quay.io before advancing ---"
+    for IMAGE in shipyard-dapper-base; do
+        if skopeo inspect --raw "docker://quay.io/submariner/${IMAGE}:${IMAGE_TAG}" >/dev/null 2>&1; then
+            echo "  OK  quay.io/submariner/${IMAGE}:${IMAGE_TAG}"
+        else
+            echo "  MISSING  quay.io/submariner/${IMAGE}:${IMAGE_TAG}"
+            IMAGES_OK=false
+        fi
+    done
+    if [ "$IMAGES_OK" = false ]; then
+        echo "WAITING: Shipyard images not yet on quay.io — will retry next poll."
+    else
+        echo ">>> Images verified. Advancing to admiral..."
+        make release VERSION="${VERSION}" $DRY_RUN_FLAG
+    fi
+fi
+```
+
+### admiral → Wait for 3 Project Dependency PRs, Then Advance
+
+The `admiral` stage: `do-release.sh` tags Admiral and creates dependency update PRs in
+cloud-prepare, lighthouse, and submariner.
+
+**Check all 3 project dependency PRs:**
+
+```bash
+echo "--- Admiral release ---"
+gh release view "v${VERSION}" --repo "${ORG}/admiral" \
+    --json tagName,publishedAt \
+    --jq '"\(.tagName) published \(.publishedAt)"' \
+    2>/dev/null || echo "NOT YET RELEASED"
+
+# Primary: get exact PR URLs from the do-release.sh comment on the releases repo stage PR
+ADMIRAL_STAGE_PR_NUM=$(gh pr list --repo "${ORG}/releases" --state merged --limit 100 \
+    --json number,title \
+    --jq ".[] | select(.title == \"Advancing ${VERSION} release to status: admiral\") | .number" \
+    | head -1)
+
+STAGE_DEP_PRS=""
+if [ -n "$ADMIRAL_STAGE_PR_NUM" ]; then
+    STAGE_DEP_PRS=$(gh api "repos/${ORG}/releases/pulls/${ADMIRAL_STAGE_PR_NUM}/reviews" \
+        --jq '.[] | select(.body | test("Release for status .admiral. finished")) | .body' \
+        | grep -oE 'https://github.com/[^[:space:]]+' || true)
+fi
+
+PROJECTS_READY=0
+PROJECTS_TOTAL=3
+for REPO in cloud-prepare lighthouse submariner; do
+    echo ""
+    echo "--- ${REPO} dependency PR ---"
+
+    # Try to get the exact URL from the comment first (scoped to this release/repo)
+    PR_URL=$(echo "$STAGE_DEP_PRS" | grep "/${REPO}/" | head -1 || true)
+
+    # Fallback: filtered search scoped to the release base branch
+    if [ -z "$PR_URL" ]; then
+        PR_URL=$(gh pr list --repo "${ORG}/${REPO}" \
+            --base "${BRANCH_VAL}" --label automated --state open \
+            --json url --jq '.[0].url // empty' 2>/dev/null || true)
+        if [ -z "$PR_URL" ]; then
+            PR_URL=$(gh pr list --repo "${ORG}/${REPO}" \
+                --base "${BRANCH_VAL}" --label automated --state merged \
+                --limit 5 --json url --jq '.[0].url // empty' 2>/dev/null || true)
+        fi
+    fi
+
+    if [ -z "$PR_URL" ]; then
+        echo "NOT YET CREATED"
+    else
+        PR_STATE=$(gh pr view "$PR_URL" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+        if [ "$PR_STATE" = "MERGED" ]; then
+            echo "MERGED: $PR_URL"
+            PROJECTS_READY=$((PROJECTS_READY + 1))
+        else
+            echo "OPEN: $PR_URL"
+            if [ "$STATUS_ONLY" = false ]; then
+                gh pr review "$PR_URL" --approve --body "Approved by automated release process" 2>/dev/null || true
+            fi
+            gh pr checks "$PR_URL" 2>/dev/null | grep -i "fail" || true
+        fi
+    fi
+done
+
+echo ""
+echo "Project dependency PRs: ${PROJECTS_READY}/${PROJECTS_TOTAL} merged"
+```
+
+**Advance when all 3 are merged:**
+
+```bash
+if [ "$PROJECTS_READY" -eq "$PROJECTS_TOTAL" ] && [ "$STATUS_ONLY" = false ]; then
+    # Admiral is a pure Go library with no container images — no quay.io check needed here.
+    echo ">>> All project dependency PRs merged. Advancing to projects..."
+    make release VERSION="${VERSION}" $DRY_RUN_FLAG
+fi
+```
+
+### projects → Wait for Operator Dependency PR, Then Advance
+
+The `projects` stage: `do-release.sh` tags cloud-prepare, lighthouse, submariner and
+creates a dependency + version update PR in submariner-operator.
+
+**Check project releases and operator dependency PR:**
+
+```bash
+echo "--- Project releases ---"
+for REPO in cloud-prepare lighthouse submariner; do
+    gh release view "v${VERSION}" --repo "${ORG}/${REPO}" \
+        --json tagName \
+        --jq "\"${REPO}: \(.tagName)\"" \
+        2>/dev/null || echo "${REPO}: NOT YET RELEASED"
+done
+
+echo ""
+echo "--- Operator dependency PR ---"
+
+# Primary: get exact PR URL from the do-release.sh comment on the releases repo stage PR
+PROJECTS_STAGE_PR_NUM=$(gh pr list --repo "${ORG}/releases" --state merged --limit 100 \
+    --json number,title \
+    --jq ".[] | select(.title == \"Advancing ${VERSION} release to status: projects\") | .number" \
+    | head -1)
+
+OPERATOR_PR_URL=""
+if [ -n "$PROJECTS_STAGE_PR_NUM" ]; then
+    OPERATOR_PR_URL=$(gh api "repos/${ORG}/releases/pulls/${PROJECTS_STAGE_PR_NUM}/reviews" \
+        --jq '.[] | select(.body | test("Release for status .projects. finished")) | .body' \
+        | grep -oE 'https://github.com/[^[:space:]]+' | head -1 || true)
+fi
+
+# Fallback: filtered search scoped to the release base branch
+if [ -z "$OPERATOR_PR_URL" ]; then
+    OPERATOR_PR_URL=$(gh pr list --repo "${ORG}/submariner-operator" \
+        --base "${BRANCH_VAL}" --label automated --state open \
+        --json url --jq '.[0].url // empty' 2>/dev/null || true)
+    if [ -z "$OPERATOR_PR_URL" ]; then
+        OPERATOR_PR_URL=$(gh pr list --repo "${ORG}/submariner-operator" \
+            --base "${BRANCH_VAL}" --label automated --state merged \
+            --limit 5 --json url --jq '.[0].url // empty' 2>/dev/null || true)
+    fi
+fi
+
+READY=false
+if [ -z "$OPERATOR_PR_URL" ]; then
+    echo "NOT YET CREATED (do-release may still be running)"
+else
+    PR_STATE=$(gh pr view "$OPERATOR_PR_URL" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+    if [ "$PR_STATE" = "MERGED" ]; then
+        echo "MERGED: $OPERATOR_PR_URL"
+        READY=true
+    else
+        echo "OPEN: $OPERATOR_PR_URL"
+        if [ "$STATUS_ONLY" = false ]; then
+            gh pr review "$OPERATOR_PR_URL" --approve --body "Approved by automated release process" 2>/dev/null || true
+        fi
+        gh pr checks "$OPERATOR_PR_URL" 2>/dev/null | grep -i "fail" || true
+    fi
+fi
+```
+
+**Advance when merged:**
+
+```bash
+if [ "$READY" = true ] && [ "$STATUS_ONLY" = false ]; then
+    IMAGE_TAG="${VERSION#v}"
+    IMAGES_OK=true
+    echo "--- Verifying project images on quay.io before advancing ---"
+    for IMAGE in submariner-gateway submariner-route-agent submariner-globalnet \
+                 lighthouse-agent lighthouse-coredns; do
+        if skopeo inspect --raw "docker://quay.io/submariner/${IMAGE}:${IMAGE_TAG}" >/dev/null 2>&1; then
+            echo "  OK  quay.io/submariner/${IMAGE}:${IMAGE_TAG}"
+        else
+            echo "  MISSING  quay.io/submariner/${IMAGE}:${IMAGE_TAG}"
+            IMAGES_OK=false
+        fi
+    done
+    if [ "$IMAGES_OK" = false ]; then
+        echo "WAITING: Project images not yet on quay.io — will retry next poll."
+    else
+        echo ">>> Images verified. Advancing to installers..."
+        make release VERSION="${VERSION}" $DRY_RUN_FLAG
+    fi
+fi
+```
+
+### installers → Wait for Subctl + Charts Dependency PRs, Then Advance
+
+The `installers` stage: `do-release.sh` tags submariner-operator and creates dependency
+update PRs in subctl and submariner-charts.
+
+**Check both dependency PRs:**
+
+```bash
+echo "--- Operator release ---"
+gh release view "v${VERSION}" --repo "${ORG}/submariner-operator" \
+    --json tagName,publishedAt \
+    --jq '"\(.tagName) published \(.publishedAt)"' \
+    2>/dev/null || echo "NOT YET RELEASED"
+
+# Primary: get exact PR URLs from the do-release.sh comment on the releases repo stage PR
+INST_STAGE_PR_NUM=$(gh pr list --repo "${ORG}/releases" --state merged --limit 100 \
+    --json number,title \
+    --jq ".[] | select(.title == \"Advancing ${VERSION} release to status: installers\") | .number" \
+    | head -1)
+
+INST_DEP_PRS=""
+if [ -n "$INST_STAGE_PR_NUM" ]; then
+    INST_DEP_PRS=$(gh api "repos/${ORG}/releases/pulls/${INST_STAGE_PR_NUM}/reviews" \
+        --jq '.[] | select(.body | test("Release for status .installers. finished")) | .body' \
+        | grep -oE 'https://github.com/[^[:space:]]+' || true)
+fi
+
+INST_READY=0
+INST_TOTAL=2
+for REPO in subctl submariner-charts; do
+    echo ""
+    echo "--- ${REPO} dependency PR ---"
+
+    # Try to get the exact URL from the comment first (scoped to this release/repo)
+    PR_URL=$(echo "$INST_DEP_PRS" | grep "/${REPO}/" | head -1 || true)
+
+    # Fallback: filtered search scoped to the release base branch
+    if [ -z "$PR_URL" ]; then
+        PR_URL=$(gh pr list --repo "${ORG}/${REPO}" \
+            --base "${BRANCH_VAL}" --label automated --state open \
+            --json url --jq '.[0].url // empty' 2>/dev/null || true)
+        if [ -z "$PR_URL" ]; then
+            PR_URL=$(gh pr list --repo "${ORG}/${REPO}" \
+                --base "${BRANCH_VAL}" --label automated --state merged \
+                --limit 5 --json url --jq '.[0].url // empty' 2>/dev/null || true)
+        fi
+    fi
+
+    if [ -z "$PR_URL" ]; then
+        echo "NOT YET CREATED"
+    else
+        PR_STATE=$(gh pr view "$PR_URL" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+        if [ "$PR_STATE" = "MERGED" ]; then
+            echo "MERGED: $PR_URL"
+            INST_READY=$((INST_READY + 1))
+        else
+            echo "OPEN: $PR_URL"
+            if [ "$STATUS_ONLY" = false ]; then
+                gh pr review "$PR_URL" --approve --body "Approved by automated release process" 2>/dev/null || true
+            fi
+            gh pr checks "$PR_URL" 2>/dev/null | grep -i "fail" || true
+        fi
+    fi
+done
+
+echo ""
+echo "Installer dependency PRs: ${INST_READY}/${INST_TOTAL} merged"
+```
+
+**Advance when both merged:**
+
+```bash
+if [ "$INST_READY" -eq "$INST_TOTAL" ] && [ "$STATUS_ONLY" = false ]; then
+    IMAGE_TAG="${VERSION#v}"
+    IMAGES_OK=true
+    echo "--- Verifying installer images on quay.io before advancing ---"
+    for IMAGE in submariner-operator subctl; do
+        if skopeo inspect --raw "docker://quay.io/submariner/${IMAGE}:${IMAGE_TAG}" >/dev/null 2>&1; then
+            echo "  OK  quay.io/submariner/${IMAGE}:${IMAGE_TAG}"
+        else
+            echo "  MISSING  quay.io/submariner/${IMAGE}:${IMAGE_TAG}"
+            IMAGES_OK=false
+        fi
+    done
+    if [ "$IMAGES_OK" = false ]; then
+        echo "WAITING: Installer images not yet on quay.io — will retry next poll."
+    else
+        echo ">>> Images verified. Advancing to released..."
+        make release VERSION="${VERSION}" $DRY_RUN_FLAG
+    fi
+fi
+```
+
+### released → Verify Final Artifacts
+
+The `released` stage: `do-release.sh` cross-compiles subctl, creates the final GitHub
+release with binaries, and tags all remaining projects.
+
+**Verify everything landed:**
+
+```bash
+echo "=== Final Release Verification ==="
+echo ""
+
+# GitHub release on releases repo (includes subctl binaries)
+echo "--- GitHub Release (releases repo) ---"
+gh release view "v${VERSION}" --repo "${ORG}/releases" \
+    --json tagName,publishedAt,assets \
+    --jq '{tag: .tagName, published: .publishedAt, assets: [.assets[].name]}' \
+    2>/dev/null || echo "NOT FOUND — do-release may still be running"
+
+# All 8 projects should be tagged
+echo ""
+echo "--- Project Tags ---"
+TAG_COUNT=0
+TAG_TOTAL=8
+for REPO in shipyard admiral cloud-prepare lighthouse submariner submariner-operator subctl submariner-charts; do
+    if gh release view "v${VERSION}" --repo "${ORG}/${REPO}" --json tagName --jq '.tagName' >/dev/null 2>&1; then
+        echo "  OK  ${REPO}"
+        TAG_COUNT=$((TAG_COUNT + 1))
+    else
+        echo "  --  ${REPO}: not tagged"
+    fi
+done
+echo "Tags: ${TAG_COUNT}/${TAG_TOTAL}"
+
+# Container images on quay.io (spot check — only checks tag existence, not content)
+echo ""
+echo "--- Container Images (quay.io) ---"
+IMAGE_TAG="${VERSION#v}"  # quay.io tags don't have 'v' prefix
+for IMAGE in submariner-gateway submariner-route-agent submariner-globalnet \
+             lighthouse-agent lighthouse-coredns submariner-operator subctl; do
+    if skopeo inspect --raw "docker://quay.io/submariner/${IMAGE}:${IMAGE_TAG}" >/dev/null 2>&1; then
+        echo "  OK  quay.io/submariner/${IMAGE}:${IMAGE_TAG}"
+    else
+        echo "  --  quay.io/submariner/${IMAGE}:${IMAGE_TAG} NOT FOUND"
+    fi
+done
+
+# Post-release workflow (krew index update)
+echo ""
+echo "--- Post-Release Workflow ---"
+gh run list --repo "${ORG}/releases" --workflow "post-release.yml" --limit 3 \
+    --json status,conclusion,createdAt \
+    --jq '.[] | "\(.status)/\(.conclusion // "—") \(.createdAt)"'
+```
+
+If all 8 tags exist and the GitHub release is published:
+
+```
+Release v${VERSION} COMPLETE.
+
+Downstream next steps (Step 7 in release workflow):
+  cd ~/konflux/submariner-release-management
+  /bundle-image-update ${VERSION}
+```
+
+If the do-release workflow is still running, report waiting.
+
+---
+
+## Error Handling
+
+When a dependency PR has failing CI checks, report the failure clearly but do NOT
+attempt to fix it. The human needs to investigate.
+
+```bash
+# Example: show failing checks on an open PR
+gh pr checks "$PR_URL" 2>/dev/null \
+    | grep -v "pass" \
+    | head -10
+```
+
+When `make release` fails:
+- Print the error output
+- Do NOT retry automatically
+- Suggest the user check `git status` and ensure their branch is clean and up-to-date
+
+When `do-release` GitHub Actions fails:
+```bash
+# Show the failed run
+FAILED_RUN=$(gh run list --repo "${ORG}/releases" --workflow "release.yml" \
+    --status failure --limit 1 --json databaseId --jq '.[0].databaseId')
+if [ -n "$FAILED_RUN" ]; then
+    echo "FAILED workflow run:"
+    gh run view --repo "${ORG}/releases" "$FAILED_RUN" --log-failed 2>/dev/null | tail -30
+fi
+```
+
+---
+
+## Notes
+
+- `make release` runs inside a Dapper container (Docker required)
+- `do-release.sh` is idempotent: it skips already-tagged repos
+- Auto-merge is enabled on all release PRs — they merge once CI passes
+- Dependency update PRs are labeled `automated` and have auto-merge
+- CI typically takes 20-40 minutes per repo
+- Full release typically takes 20-24 hours (mostly CI wait time)
+- A 10-minute `/loop` interval keeps polling under GitHub API rate limits
+  (~72 calls/hr vs 5000/hr limit)


### PR DESCRIPTION
* Adds claude skill create-release
* Adds release orchestrator agent
* Adds documentation on how to run automated release.

This adds agentic skill to reuse existing automated release scripts so that the release process can be run largely unattended once started. This doesn't save time by much as that is still gated by CI runs, but it does save the manual time and effort engineers have to spend in getting a release out by letting it run unattended once started.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated release workflow covering release preparation, validation, CI monitoring, project updates, installer updates, and completion.
  * Added status and dry-run options for reviewing release progress or previewing actions safely.
  * Added safeguards for credentials, permissions, release actions, and failure handling.

* **Documentation**
  * Added guidance for prerequisites, release procedures, downstream follow-up, troubleshooting, and operator interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->