### PR TITLE
Advancing 0.20.3 release to status: released

### DIFF
--- a/releases/v0.20.3.yaml
+++ b/releases/v0.20.3.yaml
@@ -2,7 +2,7 @@
 version: v0.20.3
 name: 0.20.3
 branch: release-0.20
-status: installers
+status: released
 components:
   shipyard: d5cc5f5fe3b40ee10abf00ea268ea33b675db6af
   admiral: f44d8649dbf1a800b572835936b7591775da0415
@@ -10,3 +10,5 @@ components:
   lighthouse: 62e7c57dffac38fbe47de546a0e90b74319c794e
   submariner: c27154c2d6eb7d4618ba11282bcb45e43f90d025
   submariner-operator: e7655d2f5093b6617fed71626c98ce4d6be4995e
+  subctl: c722fcea7d193f9c9a324b518238ca16a62514f2
+  submariner-charts: f18b41ae2af4c9f9cadcef44d869d23106a32f30


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.20
* https://github.com/submariner-io/cloud-prepare/commits/release-0.20
* https://github.com/submariner-io/lighthouse/commits/release-0.20
* https://github.com/submariner-io/shipyard/commits/release-0.20
* https://github.com/submariner-io/subctl/commits/release-0.20
* https://github.com/submariner-io/submariner/commits/release-0.20
* https://github.com/submariner-io/submariner-charts/commits/release-0.20
* https://github.com/submariner-io/submariner-operator/commits/release-0.20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked the release as published.
  * Added the latest `subctl` and `submariner-charts` build entries to the release listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->