### PR TITLE
Configure Dependabot to group GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
This groups all GitHub Actions dependency updates together to reduce the number of individual PRs and make updates easier to manage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped GitHub Actions dependency updates into a single monthly update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->