### PR TITLE
Advancing 0.24.1 release to status: released

### DIFF
--- a/releases/v0.24.1.yaml
+++ b/releases/v0.24.1.yaml
@@ -2,7 +2,7 @@
 version: v0.24.1
 name: 0.24.1
 branch: release-0.24
-status: installers
+status: released
 components:
   shipyard: 27ed0058551e057c913a023b929b0aec4fbbad73
   admiral: 253b3329b3ae89503aea7aa63f07b1ae35dadf68
@@ -10,3 +10,5 @@ components:
   lighthouse: b085fb0da7eb93dfd265fecd0341806ec06c151f
   submariner: c805541cd5ad0803e4b042750df24eaaca2e64dc
   submariner-operator: 1428e674e474bfc0322bf17c97a5a8f623861434
+  subctl: 9d8a67931dc62d543c7d3477e1c9e611fe9a2b80
+  submariner-charts: 2835c0c30a12b70047a019736e391cdb0f5f2c14


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.24
* https://github.com/submariner-io/cloud-prepare/commits/release-0.24
* https://github.com/submariner-io/lighthouse/commits/release-0.24
* https://github.com/submariner-io/shipyard/commits/release-0.24
* https://github.com/submariner-io/subctl/commits/release-0.24
* https://github.com/submariner-io/submariner/commits/release-0.24
* https://github.com/submariner-io/submariner-charts/commits/release-0.24
* https://github.com/submariner-io/submariner-operator/commits/release-0.24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 0.24.1 is now marked as released.
  * Added `subctl` and `submariner-charts` to the release components.
  * Existing component versions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->