### PR TITLE
Advancing 0.23.2 release to status: released

### DIFF
--- a/releases/v0.23.2.yaml
+++ b/releases/v0.23.2.yaml
@@ -2,7 +2,7 @@
 version: v0.23.2
 name: 0.23.2
 branch: release-0.23
-status: installers
+status: released
 components:
   shipyard: 0472f33ed4a44ef090be873bf138fe63775a3d80
   admiral: 9ff06a8b8ffe1136102d2a93043d9fc685b67488
@@ -10,3 +10,5 @@ components:
   lighthouse: b45bdfe707b8fc492a6b8282dc41f91def8cc50e
   submariner: dbbeba70d04646eb2fb971d8af8d526eee0dfb89
   submariner-operator: 8d0a352099d3a62212a7cc978361a99fe493f249
+  subctl: 6766f3732fde7f7c398f49173fb415a3a3b8bbdc
+  submariner-charts: ad9d7bd6a22c9d58f222bd5606b8c860429abf2a


### PR DESCRIPTION
Components:
* https://github.com/submariner-io/admiral/commits/release-0.23
* https://github.com/submariner-io/cloud-prepare/commits/release-0.23
* https://github.com/submariner-io/lighthouse/commits/release-0.23
* https://github.com/submariner-io/shipyard/commits/release-0.23
* https://github.com/submariner-io/subctl/commits/release-0.23
* https://github.com/submariner-io/submariner/commits/release-0.23
* https://github.com/submariner-io/submariner-charts/commits/release-0.23
* https://github.com/submariner-io/submariner-operator/commits/release-0.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Marked version 0.23.2 as released.
  * Added release entries for the `subctl` and `submariner-charts` components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->